### PR TITLE
Port to windows

### DIFF
--- a/cmd/bb_runner/main.go
+++ b/cmd/bb_runner/main.go
@@ -49,13 +49,16 @@ func main() {
 	s := grpc.NewServer()
 	runner.RegisterRunnerServer(s, runnerServer)
 
-	if err := os.Remove(runnerConfiguration.ListenPath); err != nil && !os.IsNotExist(err) {
-		log.Fatalf("Could not remove stale socket %#v: %s", runnerConfiguration.ListenPath, err)
+	if runnerConfiguration.ListenNetwork == "unix" {
+		if err := os.Remove(runnerConfiguration.ListenPath); err != nil && !os.IsNotExist(err) {
+			log.Fatalf("Could not remove stale socket %#v: %s", runnerConfiguration.ListenPath, err)
+		}
 	}
 
-	sock, err := net.Listen("unix", runnerConfiguration.ListenPath)
+	sock, err := net.Listen(runnerConfiguration.ListenNetwork, runnerConfiguration.ListenPath)
 	if err != nil {
-		log.Fatalf("Failed to create listening socket %#v: %s", runnerConfiguration.ListenPath, err)
+		log.Fatalf("Failed to create %#v listening socket %#v: %s",
+			runnerConfiguration.ListenNetwork, runnerConfiguration.ListenPath, err)
 	}
 	if err := s.Serve(sock); err != nil {
 		log.Fatal("Failed to serve RPC server: ", err)

--- a/cmd/bb_worker/BUILD.bazel
+++ b/cmd/bb_worker/BUILD.bazel
@@ -4,7 +4,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["main.go"],
+    srcs = ["main.go"] + select({
+        "@io_bazel_rules_go//go/platform:windows_amd64": ["clear_umask_windows.go"],
+        "//conditions:default": ["clear_umask_unix.go"],
+    }),
     importpath = "github.com/buildbarn/bb-remote-execution/cmd/bb_worker",
     visibility = ["//visibility:private"],
     deps = [

--- a/cmd/bb_worker/clear_umask_unix.go
+++ b/cmd/bb_worker/clear_umask_unix.go
@@ -1,0 +1,12 @@
+// +build !windows
+
+package main
+
+import (
+	"syscall"
+)
+
+// Calls syscall.Umask(0) on non-Windows systems.
+func clearUmask() {
+	syscall.Umask(0)
+}

--- a/cmd/bb_worker/clear_umask_windows.go
+++ b/cmd/bb_worker/clear_umask_windows.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package main
+
+// Calls syscall.Umask(0) on non-Windows systems.
+func clearUmask() {
+}

--- a/cmd/bb_worker/main.go
+++ b/cmd/bb_worker/main.go
@@ -8,7 +8,6 @@ import (
 	_ "net/http/pprof"
 	"net/url"
 	"os"
-	"syscall"
 	"time"
 
 	re_blobstore "github.com/buildbarn/bb-remote-execution/pkg/blobstore"
@@ -34,7 +33,7 @@ func main() {
 	// either writes files into directories that can easily be
 	// closed off, or creates files with the appropriate mode to be
 	// secure.
-	syscall.Umask(0)
+	clearUmask()
 
 	if len(os.Args) != 2 {
 		log.Fatal("Usage: bb_worker bb_worker.conf")

--- a/pkg/configuration/bb_runner/configuration.go
+++ b/pkg/configuration/bb_runner/configuration.go
@@ -22,6 +22,9 @@ func GetRunnerConfiguration(path string) (*pb.RunnerConfiguration, error) {
 }
 
 func setDefaultRunnerValues(runnerConfiguration *pb.RunnerConfiguration) {
+	if runnerConfiguration.ListenNetwork == "" {
+		runnerConfiguration.ListenNetwork = "unix"
+	}
 	if runnerConfiguration.ListenPath == "" {
 		runnerConfiguration.ListenPath = "/worker/runner"
 	}

--- a/pkg/environment/local_execution_environment.go
+++ b/pkg/environment/local_execution_environment.go
@@ -66,9 +66,9 @@ func (e *localExecutionEnvironment) Run(ctx context.Context, request *runner.Run
 	if len(request.Arguments) < 1 {
 		return nil, status.Error(codes.InvalidArgument, "Insufficient number of command arguments")
 	}
-	cmd := exec.CommandContext(ctx, request.Arguments[0], request.Arguments[1:]...)
-	// TODO(edsch): Convert workingDirectory to use platform
-	// specific path delimiter.
+	// Forward slash in the executable on Windows is interpreted as command argument. Convert to backslash.
+	executable := strings.ReplaceAll(request.Arguments[0], "/", string(filepath.Separator))
+	cmd := exec.CommandContext(ctx, executable, request.Arguments[1:]...)
 	cmd.Dir = filepath.Join(e.buildPath, request.WorkingDirectory)
 	for name, value := range request.EnvironmentVariables {
 		cmd.Env = append(cmd.Env, name+"="+value)

--- a/pkg/proto/configuration/bb_runner/bb_runner.proto
+++ b/pkg/proto/configuration/bb_runner/bb_runner.proto
@@ -8,8 +8,16 @@ message RunnerConfiguration {
   // Directory where builds take place. Defaults to "/worker/build".
   string build_directory_path = 1;
 
-  // Path on which the runner should bind its UNIX socket to wait for incoming
-  // requests through gRPC. Defaults to "/worker/runner".
+  // Network on which the runner should setup its socket to wait for incoming
+  // requests through gRPC, e.g. "tcp", "tcp4", "tcp6" or "unix" (see the
+  // Golang documentation). Defaults to "unix".
+  string listen_network = 4;
+
+  // Path on which the runner should bind its socket to wait for incoming
+  // requests through gRPC. Acceptable values depends on `listen_network`:
+  // "unix" accepts file system paths whereas "tcp4" accepts e.g.
+  // "localhost:8991" (see the Golang documentation).
+  // Defaults to "/worker/runner".
   string listen_path = 2;
 
   // Temporary directories that should be cleaned up after a build action


### PR DESCRIPTION
Apart from the three changes in this pull request, `local_directory.go` in `bb-storage` needs to be ported to Windows. See also buildbarn/bb-storage/pull/8.

This partly fixes #7.