### PR TITLE
Allow specifying the remote execution digest fn on the scheduler cmd line

### DIFF
--- a/pkg/configuration/bb_scheduler/configuration.go
+++ b/pkg/configuration/bb_scheduler/configuration.go
@@ -31,4 +31,7 @@ func setDefaultSchedulerValues(schedulerConfiguration *pb.SchedulerConfiguration
 	if schedulerConfiguration.GrpcListenAddress == "" {
 		schedulerConfiguration.GrpcListenAddress = ":8981"
 	}
+	if schedulerConfiguration.ExecutionDigestFunction == "" {
+		schedulerConfiguration.ExecutionDigestFunction = "sha256"
+	}
 }

--- a/pkg/proto/configuration/bb_scheduler/bb_scheduler.proto
+++ b/pkg/proto/configuration/bb_scheduler/bb_scheduler.proto
@@ -13,4 +13,9 @@ message SchedulerConfiguration {
 
   // Address on which to listen for RPCs. Defaults to ":8981".
   string grpc_listen_address = 3;
+
+  // Digest function reported by the server in its execution capabilities.
+  // This is a singleton for the remote execution instance.
+  // bazel checks it's the same as bazel itself is configured to use.
+  string execution_digest_function = 4;
 }


### PR DESCRIPTION
In case the bazel has to run with a function other than SHA256 - it checks that the remote executor announces the same function.
