### PR TITLE
Make the worker cache size configurable

### DIFF
--- a/cmd/bb_worker/main.go
+++ b/cmd/bb_worker/main.go
@@ -84,8 +84,9 @@ func main() {
 			cas.NewBlobAccessContentAddressableStorage(
 				re_blobstore.NewExistencePreconditionBlobAccess(contentAddressableStorageBlobAccess),
 				workerConfiguration.MaximumMessageSizeBytes),
-			util.DigestKeyWithoutInstance, cacheDirectory, 10000, 1<<30),
-		util.DigestKeyWithoutInstance, 1000)
+			util.DigestKeyWithoutInstance, cacheDirectory,
+			int(workerConfiguration.MaximumCacheFileCount), int64(workerConfiguration.MaximumCacheSizeBytes)),
+		util.DigestKeyWithoutInstance, int(workerConfiguration.MaximumMemoryCachedDirectories))
 	actionCache := ac.NewBlobAccessActionCache(actionCacheBlobAccess)
 
 	// Create connection with scheduler.

--- a/pkg/configuration/bb_worker/configuration.go
+++ b/pkg/configuration/bb_worker/configuration.go
@@ -28,11 +28,20 @@ func setDefaultWorkerValues(workerConfiguration *pb.WorkerConfiguration) {
 	if workerConfiguration.CacheDirectoryPath == "" {
 		workerConfiguration.CacheDirectoryPath = "/worker/cache"
 	}
+	if workerConfiguration.MaximumCacheFileCount == 0 {
+		workerConfiguration.MaximumCacheFileCount = 10000
+	}
+	if workerConfiguration.MaximumCacheSizeBytes == 0 {
+		workerConfiguration.MaximumCacheSizeBytes = 1024 * 1024 * 1024
+	}
+	if workerConfiguration.MaximumMemoryCachedDirectories == 0 {
+		workerConfiguration.MaximumMemoryCachedDirectories = 1000
+	}
 	if workerConfiguration.Concurrency == 0 {
 		workerConfiguration.Concurrency = 1
 	}
 	if workerConfiguration.MaximumMessageSizeBytes == 0 {
-		workerConfiguration.MaximumMessageSizeBytes = 16*1024*1024
+		workerConfiguration.MaximumMessageSizeBytes = 16 * 1024 * 1024
 	}
 	if workerConfiguration.RunnerAddress == "" {
 		workerConfiguration.RunnerAddress = "unix:///worker/runner"
@@ -41,4 +50,3 @@ func setDefaultWorkerValues(workerConfiguration *pb.WorkerConfiguration) {
 		workerConfiguration.MetricsListenAddress = ":80"
 	}
 }
-

--- a/pkg/proto/configuration/bb_worker/bb_worker.proto
+++ b/pkg/proto/configuration/bb_worker/bb_worker.proto
@@ -19,6 +19,15 @@ message WorkerConfiguration {
   // Directory where build input files are cached. Defaults to "/worker/cache".
   string cache_directory_path = 4;
 
+  // Maximum number of files in the cache. Defaults to 10000.
+  uint64 maximum_cache_file_count = 10;
+
+  // Maximum total size of the cache in bytes. Defaults to 1024*1024*1024, i.e. 1 GiB.
+  uint64 maximum_cache_size_bytes = 11;
+
+  // Maximum number of directory listings to keep in memory. Defaults to 1000.
+  uint64 maximum_memory_cached_directories = 12;
+
   // Number of actions to run concurrently. Defaults to 1.
   uint64 concurrency = 5;
 


### PR DESCRIPTION
This change removes some hard coded constants from the code. Now it will be possible set the worker cache larger than 1 GiB.