### PR TITLE
Split ContentAddressableStorage interface into reader and writer

### DIFF
--- a/internal/mock/BUILD.bazel
+++ b/internal/mock/BUILD.bazel
@@ -30,7 +30,11 @@ gomock(
 gomock(
     name = "cas",
     out = "cas.go",
-    interfaces = ["ContentAddressableStorage"],
+    interfaces = [
+        "ContentAddressableStorage",
+        "ContentAddressableStorageReader",
+        "ContentAddressableStorageWriter",
+    ],
     library = "@com_github_buildbarn_bb_storage//pkg/cas:go_default_library",
     package = "mock",
 )

--- a/pkg/builder/caching_build_executor.go
+++ b/pkg/builder/caching_build_executor.go
@@ -15,7 +15,7 @@ import (
 
 type cachingBuildExecutor struct {
 	base                      BuildExecutor
-	contentAddressableStorage cas.ContentAddressableStorage
+	contentAddressableStorage cas.ContentAddressableStorageWriter
 	actionCache               ac.ActionCache
 	browserURL                *url.URL
 }
@@ -27,7 +27,7 @@ type cachingBuildExecutor struct {
 //
 // In both cases, a link to bb_browser is added to the ExecuteResponse,
 // so that the user may inspect the Action and ActionResult in detail.
-func NewCachingBuildExecutor(base BuildExecutor, contentAddressableStorage cas.ContentAddressableStorage, actionCache ac.ActionCache, browserURL *url.URL) BuildExecutor {
+func NewCachingBuildExecutor(base BuildExecutor, contentAddressableStorage cas.ContentAddressableStorageWriter, actionCache ac.ActionCache, browserURL *url.URL) BuildExecutor {
 	return &cachingBuildExecutor{
 		base:                      base,
 		contentAddressableStorage: contentAddressableStorage,

--- a/pkg/builder/caching_build_executor_test.go
+++ b/pkg/builder/caching_build_executor_test.go
@@ -21,7 +21,7 @@ func TestCachingBuildExecutorBadActionDigest(t *testing.T) {
 	ctrl, ctx := gomock.WithContext(context.Background(), t)
 	defer ctrl.Finish()
 	baseBuildExecutor := mock.NewMockBuildExecutor(ctrl)
-	contentAddressableStorage := mock.NewMockContentAddressableStorage(ctrl)
+	contentAddressableStorage := mock.NewMockContentAddressableStorageWriter(ctrl)
 	actionCache := mock.NewMockActionCache(ctrl)
 	cachingBuildExecutor := builder.NewCachingBuildExecutor(baseBuildExecutor, contentAddressableStorage, actionCache, &url.URL{
 		Scheme: "https",
@@ -48,7 +48,7 @@ func TestCachingBuildExecutorNoResult(t *testing.T) {
 	}).Return(&remoteexecution.ExecuteResponse{
 		Status: status.New(codes.Internal, "Hard disk on fire").Proto(),
 	}, false)
-	contentAddressableStorage := mock.NewMockContentAddressableStorage(ctrl)
+	contentAddressableStorage := mock.NewMockContentAddressableStorageWriter(ctrl)
 	actionCache := mock.NewMockActionCache(ctrl)
 	cachingBuildExecutor := builder.NewCachingBuildExecutor(baseBuildExecutor, contentAddressableStorage, actionCache, &url.URL{
 		Scheme: "https",
@@ -84,7 +84,7 @@ func TestCachingBuildExecutorCachedSuccess(t *testing.T) {
 			StdoutRaw: []byte("Hello, world!"),
 		},
 	}, true)
-	contentAddressableStorage := mock.NewMockContentAddressableStorage(ctrl)
+	contentAddressableStorage := mock.NewMockContentAddressableStorageWriter(ctrl)
 	actionCache := mock.NewMockActionCache(ctrl)
 	actionCache.EXPECT().PutActionResult(
 		ctx,
@@ -131,7 +131,7 @@ func TestCachingBuildExecutorCachedFailure(t *testing.T) {
 			StdoutRaw: []byte("Hello, world!"),
 		},
 	}, true)
-	contentAddressableStorage := mock.NewMockContentAddressableStorage(ctrl)
+	contentAddressableStorage := mock.NewMockContentAddressableStorageWriter(ctrl)
 	actionCache := mock.NewMockActionCache(ctrl)
 	actionCache.EXPECT().PutActionResult(
 		ctx,
@@ -176,7 +176,7 @@ func TestCachingBuildExecutorUncachedSuccess(t *testing.T) {
 			StderrRaw: []byte("Compilation failed"),
 		},
 	}, false)
-	contentAddressableStorage := mock.NewMockContentAddressableStorage(ctrl)
+	contentAddressableStorage := mock.NewMockContentAddressableStorageWriter(ctrl)
 	contentAddressableStorage.EXPECT().PutUncachedActionResult(
 		ctx,
 		&cas_proto.UncachedActionResult{
@@ -232,7 +232,7 @@ func TestCachingBuildExecutorUncachedFailure(t *testing.T) {
 			StderrRaw: []byte("Compilation failed"),
 		},
 	}, false)
-	contentAddressableStorage := mock.NewMockContentAddressableStorage(ctrl)
+	contentAddressableStorage := mock.NewMockContentAddressableStorageWriter(ctrl)
 	contentAddressableStorage.EXPECT().PutUncachedActionResult(
 		ctx,
 		&cas_proto.UncachedActionResult{

--- a/pkg/cas/directory_caching_content_addressable_storage.go
+++ b/pkg/cas/directory_caching_content_addressable_storage.go
@@ -11,7 +11,7 @@ import (
 )
 
 type directoryCachingContentAddressableStorage struct {
-	cas.ContentAddressableStorage
+	cas.ContentAddressableStorageReader
 
 	lock sync.RWMutex
 
@@ -23,12 +23,12 @@ type directoryCachingContentAddressableStorage struct {
 }
 
 // NewDirectoryCachingContentAddressableStorage is an adapter for
-// ContentAddressableStorage that caches up a fixed number of
+// ContentAddressableStorageReader that caches up a fixed number of
 // unmarshalled directory objects in memory. This reduces the amount of
 // network traffic needed.
-func NewDirectoryCachingContentAddressableStorage(base cas.ContentAddressableStorage, digestKeyFormat util.DigestKeyFormat, maxDirectories int) cas.ContentAddressableStorage {
+func NewDirectoryCachingContentAddressableStorage(base cas.ContentAddressableStorageReader, digestKeyFormat util.DigestKeyFormat, maxDirectories int) cas.ContentAddressableStorageReader {
 	return &directoryCachingContentAddressableStorage{
-		ContentAddressableStorage: base,
+		ContentAddressableStorageReader: base,
 
 		digestKeyFormat: digestKeyFormat,
 		maxDirectories:  maxDirectories,
@@ -63,7 +63,7 @@ func (cas *directoryCachingContentAddressableStorage) GetDirectory(ctx context.C
 	}
 
 	// Not found. Download directory.
-	directory, err := cas.ContentAddressableStorage.GetDirectory(ctx, digest)
+	directory, err := cas.ContentAddressableStorageReader.GetDirectory(ctx, digest)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cas/hardlinking_content_addressable_storage.go
+++ b/pkg/cas/hardlinking_content_addressable_storage.go
@@ -29,7 +29,7 @@ func init() {
 }
 
 type hardlinkingContentAddressableStorage struct {
-	cas.ContentAddressableStorage
+	cas.ContentAddressableStorageReader
 
 	lock sync.RWMutex
 
@@ -44,14 +44,14 @@ type hardlinkingContentAddressableStorage struct {
 }
 
 // NewHardlinkingContentAddressableStorage is an adapter for
-// ContentAddressableStorage that stores files in an internal directory. After
+// ContentAddressableStorageReader that stores files in an internal directory. After
 // successfully downloading files at the target location, they are hardlinked
 // into the cache. Future calls for the same file will hardlink them from the
 // cache to the target location. This reduces the amount of network traffic
 // needed.
-func NewHardlinkingContentAddressableStorage(base cas.ContentAddressableStorage, digestKeyFormat util.DigestKeyFormat, cacheDirectory filesystem.Directory, maxFiles int, maxSize int64) cas.ContentAddressableStorage {
+func NewHardlinkingContentAddressableStorage(base cas.ContentAddressableStorageReader, digestKeyFormat util.DigestKeyFormat, cacheDirectory filesystem.Directory, maxFiles int, maxSize int64) cas.ContentAddressableStorageReader {
 	return &hardlinkingContentAddressableStorage{
-		ContentAddressableStorage: base,
+		ContentAddressableStorageReader: base,
 
 		digestKeyFormat: digestKeyFormat,
 		cacheDirectory:  cacheDirectory,
@@ -101,7 +101,7 @@ func (cas *hardlinkingContentAddressableStorage) GetFile(ctx context.Context, di
 	hardlinkingContentAddressableStorageOperationsTotalMiss.Inc()
 
 	// Download the file at the intended location.
-	if err := cas.ContentAddressableStorage.GetFile(ctx, digest, directory, name, isExecutable); err != nil {
+	if err := cas.ContentAddressableStorageReader.GetFile(ctx, digest, directory, name, isExecutable); err != nil {
 		return err
 	}
 

--- a/pkg/cas/read_write_decoupling_content_addressable_storage.go
+++ b/pkg/cas/read_write_decoupling_content_addressable_storage.go
@@ -11,8 +11,8 @@ import (
 )
 
 type readWriteDecouplingContentAddressableStorage struct {
-	reader cas.ContentAddressableStorage
-	writer cas.ContentAddressableStorage
+	reader cas.ContentAddressableStorageReader
+	writer cas.ContentAddressableStorageWriter
 }
 
 // NewReadWriteDecouplingContentAddressableStorage takes a pair of
@@ -20,7 +20,7 @@ type readWriteDecouplingContentAddressableStorage struct {
 // requests to them, respectively. It can, for example, be used to
 // forward read requests to a process-wide cache, while write requests
 // are sent to a worker/action-specific write cache.
-func NewReadWriteDecouplingContentAddressableStorage(reader cas.ContentAddressableStorage, writer cas.ContentAddressableStorage) cas.ContentAddressableStorage {
+func NewReadWriteDecouplingContentAddressableStorage(reader cas.ContentAddressableStorageReader, writer cas.ContentAddressableStorageWriter) cas.ContentAddressableStorage {
 	return &readWriteDecouplingContentAddressableStorage{
 		reader: reader,
 		writer: writer,


### PR DESCRIPTION
It is possible to split the `ContentAddressableStorage` interface into a reader and a writer. `ReadWriteDecouplingContentAddressableStorage` already exists and is using one reader and one writer, so this split is a natural refactoring.