### PR TITLE
Fix output directory creation to be relative to working directory

### DIFF
--- a/pkg/builder/local_build_executor.go
+++ b/pkg/builder/local_build_executor.go
@@ -272,9 +272,6 @@ func (be *localBuildExecutor) Execute(ctx context.Context, filePool re_filesyste
 	// there. We later use the directory handles to extract output files.
 	outputParentDirectories := map[string]filesystem.Directory{}
 	workingDirectory := command.WorkingDirectory
-	if workingDirectory == "" {
-		workingDirectory = "."
-	}
 	for _, outputDirectory := range command.OutputDirectories {
 		dirPath := newOutputDirectory(workingDirectory, path.Dir(outputDirectory)).Path()
 		if _, ok := outputParentDirectories[dirPath]; !ok {


### PR DESCRIPTION
REv2 mandates that output directories are created relative to
the working directory. Currently buildbarn creates these directories
relative to the build directory.

Construct output directory paths that are relative to the build
directory, as required by the filesystem package, but that are
relative to the working directory, as required by REv2

Closes #18 