### PR TITLE
Enable more autoformatters on our codebase

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+Language: Proto
+BasedOnStyle: Google

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -7,26 +7,20 @@ on:
     branches:
     - master
 jobs:
-  gofmt:
-    runs-on: ubuntu-latest
-    container: docker://golang:1.13
-    steps:
-    - uses: actions/checkout@v1
-    - name: run gofmt
-      run: test -z "$(gofmt -d . | tee /dev/stderr)"
-  buildifier:
-    runs-on: ubuntu-latest
-    container: docker://golang:1.13
-    steps:
-    - uses: actions/checkout@v1
-    - name: install buildifier
-      run: go get github.com/bazelbuild/buildtools/buildifier
-    - name: run buildifier
-      run: buildifier -mode=check -r .
   build_and_test:
     runs-on: ubuntu-latest
     container: docker://l.gcr.io/google/bazel:2.1.0
     steps:
     - uses: actions/checkout@v1
-    - name: build and test
+    - name: Bazel build and test
       run: bazel test //...
+    - name: Buildifier
+      run: bazel run @com_github_bazelbuild_buildtools//:buildifier
+    - name: Gazelle
+      run: bazel run //:gazelle
+    - name: Gofmt
+      run: bazel run @go_sdk//:bin/gofmt -- -s -w .
+    - name: Clang format
+      run: find . -name '*.proto' -exec bazel run @llvm_toolchain//:bin/clang-format -- -i {} +
+    - name: Test style conformance
+      run: git diff --exit-code HEAD --

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -116,3 +116,17 @@ http_file(
     sha256 = "eadb9d6e2dc960655481d78a92d2c8bc021861045987ccd3e27c7eae5af0cf33",
     urls = ["https://github.com/krallin/tini/releases/download/v0.18.0/tini-static-amd64"],
 )
+
+http_archive(
+    name = "com_grail_bazel_toolchain",
+    sha256 = "b3dec631fe2be45b3a7a8a4161dd07fadc68825842e8d6305ed35bc8560968ca",
+    strip_prefix = "bazel-toolchain-0.5.1",
+    urls = ["https://github.com/grailbio/bazel-toolchain/archive/0.5.1.tar.gz"],
+)
+
+load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
+
+llvm_toolchain(
+    name = "llvm_toolchain",
+    llvm_version = "9.0.0",
+)

--- a/pkg/builder/storage_flushing_build_executor_test.go
+++ b/pkg/builder/storage_flushing_build_executor_test.go
@@ -83,7 +83,7 @@ func TestStorageFlushingBuildExecutor(t *testing.T) {
 			},
 		},
 		ServerLogs: map[string]*remoteexecution.LogFile{
-			"kernel_log": &remoteexecution.LogFile{
+			"kernel_log": {
 				Digest: &remoteexecution.Digest{
 					Hash:      "2917c2a7eb23012392098e74a873cd31",
 					SizeBytes: 9584,


### PR DESCRIPTION
Instead of having separate containers that do a 'go get' to obtain these
tools, fetch all of them through the Bazel workspace. This ensures that
we always stick to a fixed version.