### PR TITLE
Sort worker platform properties

### DIFF
--- a/pkg/builder/build_client.go
+++ b/pkg/builder/build_client.go
@@ -8,6 +8,7 @@ import (
 	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/buildbarn/bb-remote-execution/pkg/filesystem"
 	"github.com/buildbarn/bb-remote-execution/pkg/proto/remoteworker"
+	re_util "github.com/buildbarn/bb-remote-execution/pkg/util"
 	"github.com/buildbarn/bb-storage/pkg/clock"
 	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/golang/protobuf/ptypes"
@@ -39,7 +40,9 @@ type BuildClient struct {
 
 // NewBuildClient creates a new BuildClient instance that is set to the
 // initial state (i.e., being idle).
-func NewBuildClient(scheduler remoteworker.OperationQueueClient, buildExecutor BuildExecutor, filePool filesystem.FilePool, clock clock.Clock, browserURL *url.URL, workerID map[string]string, instanceName string, platform *remoteexecution.Platform) *BuildClient {
+func NewBuildClient(scheduler remoteworker.OperationQueueClient, buildExecutor BuildExecutor,
+	filePool filesystem.FilePool, clock clock.Clock, browserURL *url.URL,
+	workerID map[string]string, instanceName string, platform *remoteexecution.Platform) *BuildClient {
 	return &BuildClient{
 		scheduler:     scheduler,
 		buildExecutor: buildExecutor,
@@ -49,7 +52,7 @@ func NewBuildClient(scheduler remoteworker.OperationQueueClient, buildExecutor B
 		request: remoteworker.SynchronizeRequest{
 			WorkerId:     workerID,
 			InstanceName: instanceName,
-			Platform:     platform,
+			Platform:     re_util.SortPlatformProperties(platform),
 			CurrentState: &remoteworker.CurrentState{
 				WorkerState: &remoteworker.CurrentState_Idle{
 					Idle: &empty.Empty{},

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -1,9 +1,31 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["browser_url.go"],
+    srcs = [
+        "browser_url.go",
+        "platforms.go",
+    ],
     importpath = "github.com/buildbarn/bb-remote-execution/pkg/util",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_buildbarn_bb_storage//pkg/digest:go_default_library"],
+    deps = [
+        "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
+        "@com_github_buildbarn_bb_storage//pkg/digest:go_default_library",
+    ],
+)
+
+go_test(
+    name = "util_tests",
+    srcs = ["platforms_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["platforms_test.go"],
+    embed = [":go_default_library"],
+    deps = ["@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library"],
 )

--- a/pkg/util/platforms.go
+++ b/pkg/util/platforms.go
@@ -1,0 +1,18 @@
+package util
+
+import (
+	"sort"
+
+	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+)
+
+type ByPlatformProperty []*remoteexecution.Platform_Property
+
+func (a ByPlatformProperty) Len() int           { return len(a) }
+func (a ByPlatformProperty) Less(i, j int) bool { return a[i].Name < a[j].Name }
+func (a ByPlatformProperty) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+
+func SortPlatformProperties(platform *remoteexecution.Platform) *remoteexecution.Platform {
+	sort.Sort(ByPlatformProperty(platform.Properties))
+	return platform
+}

--- a/pkg/util/platforms_test.go
+++ b/pkg/util/platforms_test.go
@@ -1,0 +1,23 @@
+package util_test
+
+import (
+	"fmt"
+	"testing"
+
+	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+	re_util "github.com/buildbarn/bb-remote-execution/pkg/util"
+)
+
+func TestSortPlatformProperties(t *testing.T) {
+	reverseSortedPlatform := &remoteexecution.Platform{
+		Properties: []*remoteexecution.Platform_Property{
+			{Name: "os", Value: "armv6"},
+			{Name: "cpu", Value: "linux"},
+		},
+	}
+
+	sortedPlatform := re_util.SortPlatformProperties(reverseSortedPlatform)
+	if sortedPlatform.Properties[0].Name == "os" {
+		t.Errorf("Platform properties did not sort correctly")
+	}
+}


### PR DESCRIPTION
Currently bb-worker expects the platform properties to be sorted by name as specified by the REAPI spec. Unfortunately this is quite inconvenient for the user configuring the workers as it does not cause the worker process to exit, it is constantly rejected by the scheduler for this. (Perhaps the scheduler needs to raise a different error which causes the worker to exit).

This PR sorts these before they are passed to the build client ensuring that any ordering of platform properties in the bb-worker configuration will be sorted by bb_worker to ensure that the spec is followed.