### PR TITLE
bb_runner chroot

### DIFF
--- a/cmd/bb_runner/BUILD.bazel
+++ b/cmd/bb_runner/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@com_github_buildbarn_bb_storage//tools:container.bzl", "container_push_official")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_layer")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
@@ -83,6 +84,13 @@ container_image(
     visibility = ["//visibility:public"],
 )
 
+go_image(
+    name = "bb_runner_bare_container",
+    embed = [":go_default_library"],
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
+
 container_push_official(
     name = "bb_runner_ubuntu16_04_container_push",
     component = "bb-runner-ubuntu16-04",
@@ -93,4 +101,10 @@ container_push_official(
     name = "bb_runner_installer_push",
     component = "bb-runner-installer",
     image = ":bb_runner_installer",
+)
+
+container_push_official(
+    name = "bb_runner_bare_container_push",
+    component = "bb-runner-bare",
+    image = ":bb_runner_bare_container",
 )

--- a/cmd/bb_runner/main.go
+++ b/cmd/bb_runner/main.go
@@ -39,7 +39,8 @@ func main() {
 	r := runner.NewLocalRunner(
 		buildDirectory,
 		configuration.BuildDirectoryPath,
-		configuration.SetTmpdirEnvironmentVariable)
+		configuration.SetTmpdirEnvironmentVariable,
+		configuration.ChrootIntoInputRoot)
 
 	// When temporary directories need cleaning prior to executing a build
 	// action, attach a series of TemporaryDirectoryCleaningRunners.

--- a/pkg/proto/configuration/bb_runner/bb_runner.proto
+++ b/pkg/proto/configuration/bb_runner/bb_runner.proto
@@ -32,6 +32,8 @@ message ApplicationConfiguration {
   buildbarn.configuration.grpc.ClientConfiguration
       temporary_directory_installer = 6;
 
-  // Chroot into the input root to run commands
+  // Chroot into the input root to run commands. This option can be used
+  // if the input root contains a full userland installation. This
+  // feature is used by the BuildStream build system.
   bool chroot_into_input_root = 7;
 }

--- a/pkg/proto/configuration/bb_runner/bb_runner.proto
+++ b/pkg/proto/configuration/bb_runner/bb_runner.proto
@@ -31,4 +31,7 @@ message ApplicationConfiguration {
   // Optional helper process for resolving /tmp.
   buildbarn.configuration.grpc.ClientConfiguration
       temporary_directory_installer = 6;
+
+  // Chroot into the input root to run commands
+  bool chroot_into_input_root = 7;
 }

--- a/pkg/runner/local_runner.go
+++ b/pkg/runner/local_runner.go
@@ -74,6 +74,11 @@ func (r *localRunner) Run(ctx context.Context, request *runner.RunRequest) (*run
 	}
 	var cmd *exec.Cmd
 	if r.chrootIntoInputRoot {
+		// The addition of /usr/bin/env is necessary as the PATH resolution
+		// will take place prior to the chroot, so the executable may not be
+		// found by exec.LookPath() inside exec.CommandContext() and may
+		// cause cmd.Start() to fail when it shouldn't.
+		// https://github.com/golang/go/issues/39341
 		envPrependedArguments := []string{"/usr/bin/env", "--"}
 		envPrependedArguments = append(envPrependedArguments, request.Arguments...)
 		cmd = exec.CommandContext(ctx, envPrependedArguments[0], envPrependedArguments[1:]...)

--- a/pkg/runner/local_runner_test.go
+++ b/pkg/runner/local_runner_test.go
@@ -31,7 +31,7 @@ func TestLocalRunner(t *testing.T) {
 		// variables should cause the process to be executed in
 		// an empty environment. It should not inherit the
 		// environment of the runner.
-		runner := runner.NewLocalRunner(buildDirectory, buildDirectoryPath, false)
+		runner := runner.NewLocalRunner(buildDirectory, buildDirectoryPath, false, false)
 		response, err := runner.Run(context.Background(), &runner_pb.RunRequest{
 			Arguments:          []string{"/usr/bin/env"},
 			StdoutPath:         "EmptyEnvironment/stdout",
@@ -61,7 +61,7 @@ func TestLocalRunner(t *testing.T) {
 		// The environment variables provided in the RunRequest
 		// should be respected. If automatic injection of TMPDIR
 		// is enabled, that variable should also be added.
-		runner := runner.NewLocalRunner(buildDirectory, buildDirectoryPath, true)
+		runner := runner.NewLocalRunner(buildDirectory, buildDirectoryPath, true, false)
 		response, err := runner.Run(context.Background(), &runner_pb.RunRequest{
 			Arguments: []string{"/usr/bin/env"},
 			EnvironmentVariables: map[string]string{
@@ -98,7 +98,7 @@ func TestLocalRunner(t *testing.T) {
 
 		// Automatic injection of TMPDIR should have no effect
 		// if the command to be run provides its own TMPDIR.
-		runner := runner.NewLocalRunner(buildDirectory, buildDirectoryPath, true)
+		runner := runner.NewLocalRunner(buildDirectory, buildDirectoryPath, true, false)
 		response, err := runner.Run(context.Background(), &runner_pb.RunRequest{
 			Arguments: []string{"/usr/bin/env"},
 			EnvironmentVariables: map[string]string{
@@ -131,7 +131,7 @@ func TestLocalRunner(t *testing.T) {
 		// RunResponse. POSIX 2008 and later added support for
 		// 32-bit signed exit codes. Most implementations still
 		// truncate the exit code to 8 bits.
-		runner := runner.NewLocalRunner(buildDirectory, buildDirectoryPath, false)
+		runner := runner.NewLocalRunner(buildDirectory, buildDirectoryPath, false, false)
 		response, err := runner.Run(context.Background(), &runner_pb.RunRequest{
 			Arguments:          []string{"/bin/sh", "-c", "exit 255"},
 			StdoutPath:         "NonZeroExitCode/stdout",


### PR DESCRIPTION
This allows bb_runner to chroot into the input root of the action it is running. This can be enabled by the ChrootIntoInputRoot boolean flag in the bb_runner configuration.

It also adds a second container image based on the alpine distribution which can be used when the chroot option is enabled as it is much more lightweight.