### PR TITLE
Avoid caching directory filehandles during action execution (fixes #46)

### DIFF
--- a/pkg/builder/local_build_executor.go
+++ b/pkg/builder/local_build_executor.go
@@ -191,7 +191,7 @@ func newOutputDirectories(command *remoteexecution.Command, inputRootDirectory f
 
 	dirs := outputDirectories(map[string]filesystem.DirectoryCloser{})
 
-	for p, _ := range paths {
+	for p := range paths {
 		dir, err := getOutputDirectory(inputRootDirectory, path.Join(command.WorkingDirectory, p), create)
 		if err != nil {
 			dirs.Close()


### PR DESCRIPTION
Refactor this code so that we can run the same logic before and after
execution: once to create the output directories, then again to find
them by path. This lets us handle the case where the action deletes
and recreates the directory.