### PR TITLE
Allows multiple files/folders to be downloaded at one time

### DIFF
--- a/cmd/bb_worker/BUILD.bazel
+++ b/cmd/bb_worker/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/proto/runner:go_default_library",
         "//pkg/runner:go_default_library",
         "//pkg/sync:go_default_library",
+        "//pkg/util:go_default_library",
         "@com_github_buildbarn_bb_storage//pkg/blobstore:go_default_library",
         "@com_github_buildbarn_bb_storage//pkg/blobstore/configuration:go_default_library",
         "@com_github_buildbarn_bb_storage//pkg/cas:go_default_library",

--- a/cmd/bb_worker/main.go
+++ b/cmd/bb_worker/main.go
@@ -21,6 +21,7 @@ import (
 	runner_pb "github.com/buildbarn/bb-remote-execution/pkg/proto/runner"
 	"github.com/buildbarn/bb-remote-execution/pkg/runner"
 	"github.com/buildbarn/bb-remote-execution/pkg/sync"
+	re_util "github.com/buildbarn/bb-remote-execution/pkg/util"
 	"github.com/buildbarn/bb-storage/pkg/blobstore"
 	blobstore_configuration "github.com/buildbarn/bb-storage/pkg/blobstore/configuration"
 	"github.com/buildbarn/bb-storage/pkg/cas"
@@ -74,6 +75,11 @@ func main() {
 		}
 		filePool = re_filesystem.NewDirectoryBackedFilePool(filePoolDirectory)
 	}
+
+	if configuration.SharedActionQueueSize < 1 {
+		log.Fatal("shared_action_queue_size must be set and greater than zero.")
+	}
+	sharedActionQueue := re_util.NewSharedActionQueue(configuration.SharedActionQueueSize)
 
 	// Storage access.
 	contentAddressableStorageBlobAccess, actionCache, err := blobstore_configuration.CreateBlobAccessObjectsFromConfig(
@@ -203,7 +209,9 @@ func main() {
 				case *bb_worker.ApplicationConfiguration_LocalBuildDirectory:
 					buildDirectory = builder.NewNaiveBuildDirectory(
 						naiveBuildDirectory,
-						contentAddressableStorage)
+						contentAddressableStorage,
+						sharedActionQueue,
+					)
 				}
 
 				// Create a per-action subdirectory in

--- a/pkg/builder/BUILD.bazel
+++ b/pkg/builder/BUILD.bazel
@@ -78,6 +78,7 @@ go_test(
         "//pkg/proto/resourceusage:go_default_library",
         "//pkg/proto/runner:go_default_library",
         "//pkg/sync:go_default_library",
+        "//pkg/util:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_buildbarn_bb_storage//pkg/blobstore/buffer:go_default_library",
         "@com_github_buildbarn_bb_storage//pkg/builder:go_default_library",

--- a/pkg/proto/configuration/bb_worker/bb_worker.proto
+++ b/pkg/proto/configuration/bb_worker/bb_worker.proto
@@ -48,6 +48,11 @@ message ApplicationConfiguration {
   // stored. If left empty, temporary files are stored in memory.
   string file_pool_directory_path = 18;
 
+  // The size of concurrent actions that can be run at any given time.
+  // This many goroutines and concurrent streams will be allowed at
+  // any given time.
+  uint32 shared_action_queue_size = 20;
+
   // Common configuration options that apply to all Buildbarn binaries.
   buildbarn.configuration.global.Configuration global = 19;
 }

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -1,9 +1,22 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["browser_url.go"],
+    srcs = [
+        "browser_url.go",
+        "shared_action_queue.go",
+    ],
     importpath = "github.com/buildbarn/bb-remote-execution/pkg/util",
     visibility = ["//visibility:public"],
     deps = ["@com_github_buildbarn_bb_storage//pkg/digest:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["shared_action_queue_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "@com_github_golang_mock//gomock:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+    ],
 )

--- a/pkg/util/shared_action_queue.go
+++ b/pkg/util/shared_action_queue.go
@@ -1,0 +1,100 @@
+package util
+
+import (
+	"context"
+	"sync"
+)
+
+type ActionContext struct {
+	ctx        context.Context
+	cancelFunc context.CancelFunc
+	wg         sync.WaitGroup
+	results    chan error
+	isWaiting  bool
+}
+
+type Action = func(*ActionContext)
+type ActionGroup = []Action
+
+type SharedActionQueue struct {
+	sharedActionQueue chan func()
+}
+
+// This is a utility designed to run 'Action's to do some work async but limit
+// by a pre-defined number. This allows multiple components to share the same
+// pool of goroutines or other similar resources (like data streams) easily.
+func NewSharedActionQueue(maxConcurrentDownloads uint32) *SharedActionQueue {
+	sharedActionQueue := make(chan func(), maxConcurrentDownloads)
+	for i := uint32(0); i < maxConcurrentDownloads; i++ {
+		go func() {
+			for {
+				action, ok := <-sharedActionQueue
+				if !ok {
+					return // Looks like our channel is closed.
+				}
+				action()
+			}
+		}()
+	}
+	return &SharedActionQueue{
+		sharedActionQueue: sharedActionQueue,
+	}
+}
+
+// Enqueues all provided actions onto a shared limit action queue.
+// Will only return the first error discovered and will always block
+// until all actions are finished before returning.
+func (saq *SharedActionQueue) ProcessActionQueue(ctx context.Context, actionGroup ActionGroup) *ActionContext {
+	newCtx, cancelFunc := context.WithCancel(ctx)
+	actionContext := ActionContext{
+		ctx:        newCtx,
+		cancelFunc: cancelFunc,
+		wg:         sync.WaitGroup{},
+		results:    make(chan error, len(actionGroup)),
+		isWaiting:  false,
+	}
+	for _, action := range actionGroup {
+		actionContext.wg.Add(1)
+		actionCopy := action // Warning: Golang likes to capture by reference causing our lambda to get the same function.
+		saq.sharedActionQueue <- func() {
+			actionCopy(&actionContext)
+		}
+	}
+	return &actionContext
+}
+
+func (ac *ActionContext) Ctx() context.Context {
+	return ac.ctx
+}
+
+func (ac *ActionContext) Done(result error) {
+	ac.results <- result
+	if result != nil {
+		ac.cancelFunc() // Trigger all actions in our ActionGroup to cancel.
+	}
+	ac.wg.Done()
+}
+
+func (ac *ActionContext) Defer() func(error) {
+	return func(result error) {
+		ac.Done(result)
+	}
+}
+
+func (ac *ActionContext) WaitForResult() error {
+	if ac.isWaiting { // Technically this isn't thread-safe, but its an assertion anyway.
+		panic("Assertion failed. WaitForResult() can only be called once per ActionContext")
+	}
+	ac.isWaiting = true
+	// Wait for all passed in actions to finish. We don't return on
+	// first error in fear of introducing bugs around lifetime.
+	ac.wg.Wait()
+	close(ac.results)
+
+	for err := range ac.results {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/util/shared_action_queue_test.go
+++ b/pkg/util/shared_action_queue_test.go
@@ -1,0 +1,147 @@
+package util_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	re_util "github.com/buildbarn/bb-remote-execution/pkg/util"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSharedActionQueue(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("RunOneItemSuccess", func(t *testing.T) {
+		saq := re_util.NewSharedActionQueue(10)
+		actionGroup := re_util.ActionGroup{}
+		expectedActionsExecuted := 1
+		didRunActionChan := make(chan struct{}, expectedActionsExecuted)
+		actionGroup = append(actionGroup, func(ac *re_util.ActionContext) {
+			didRunActionChan <- struct{}{}
+			ac.Done(nil)
+		})
+		result := saq.ProcessActionQueue(context.Background(), actionGroup).WaitForResult()
+		require.NoError(t, result)
+		require.Equal(t, len(didRunActionChan), expectedActionsExecuted)
+	})
+
+	t.Run("TwoRunsFirstOneFailsSecondSucceeds", func(t *testing.T) {
+		saq := re_util.NewSharedActionQueue(10)
+		actionGroup := re_util.ActionGroup{}
+		expectedActionsExecuted := 2
+		didRunActionChan := make(chan struct{}, expectedActionsExecuted)
+		actionGroup = append(actionGroup, func(ac *re_util.ActionContext) {
+			didRunActionChan <- struct{}{}
+			ac.Done(errors.New("Error42"))
+		})
+		actionGroup = append(actionGroup, func(ac *re_util.ActionContext) {
+			didRunActionChan <- struct{}{}
+			ac.Done(nil)
+		})
+		result := saq.ProcessActionQueue(context.Background(), actionGroup).WaitForResult()
+		require.EqualError(t, result, "Error42")
+		require.Equal(t, len(didRunActionChan), expectedActionsExecuted)
+	})
+
+	t.Run("TwoRunsFirstOneSucceedsSecondFails", func(t *testing.T) {
+		saq := re_util.NewSharedActionQueue(10)
+		actionGroup := re_util.ActionGroup{}
+		expectedActionsExecuted := 2
+		didRunActionChan := make(chan struct{}, expectedActionsExecuted)
+		actionGroup = append(actionGroup, func(ac *re_util.ActionContext) {
+			didRunActionChan <- struct{}{}
+			ac.Done(nil)
+		})
+		actionGroup = append(actionGroup, func(ac *re_util.ActionContext) {
+			didRunActionChan <- struct{}{}
+			ac.Done(errors.New("Error42-1"))
+		})
+		result := saq.ProcessActionQueue(context.Background(), actionGroup).WaitForResult()
+		require.EqualError(t, result, "Error42-1")
+		require.Equal(t, len(didRunActionChan), expectedActionsExecuted)
+	})
+
+	// Note this test we invert the order so the first Action resolves after
+	// the second.
+	t.Run("TwoRunsBothFailOnlyFirstFailureReturned", func(t *testing.T) {
+		saq := re_util.NewSharedActionQueue(10)
+		actionGroup := re_util.ActionGroup{}
+		expectedActionsExecuted := 2
+		didRunActionChan := make(chan struct{}, expectedActionsExecuted)
+		waitForSecondThreadToFinishChan := make(chan struct{})
+		actionGroup = append(actionGroup, func(ac *re_util.ActionContext) {
+			<-waitForSecondThreadToFinishChan
+			didRunActionChan <- struct{}{}
+			ac.Done(errors.New("Error42-1"))
+		})
+		actionGroup = append(actionGroup, func(ac *re_util.ActionContext) {
+			didRunActionChan <- struct{}{}
+			ac.Done(errors.New("Error42-2"))
+			waitForSecondThreadToFinishChan <- struct{}{}
+		})
+		result := saq.ProcessActionQueue(context.Background(), actionGroup).WaitForResult()
+		require.EqualError(t, result, "Error42-2")
+		require.Equal(t, len(didRunActionChan), expectedActionsExecuted)
+	})
+
+	t.Run("ProcessActionQueueWhileExecuting", func(t *testing.T) {
+		saq := re_util.NewSharedActionQueue(10)
+		actionGroup := re_util.ActionGroup{}
+		expectedActionsExecuted := 3
+		didRunActionChan := make(chan struct{}, expectedActionsExecuted)
+		actionGroup = append(actionGroup, func(ac *re_util.ActionContext) {
+			didRunActionChan <- struct{}{}
+			actionGroup2 := re_util.ActionGroup{}
+			doneHandler := ac.Defer()
+			go func() {
+				actionGroup2 = append(actionGroup2, func(ac *re_util.ActionContext) {
+					didRunActionChan <- struct{}{}
+					ac.Done(nil)
+				})
+				actionGroup2 = append(actionGroup2, func(ac *re_util.ActionContext) {
+					didRunActionChan <- struct{}{}
+					ac.Done(nil)
+				})
+				err := saq.ProcessActionQueue(ac.Ctx(), actionGroup2).WaitForResult()
+				doneHandler(err)
+			}()
+		})
+		result := saq.ProcessActionQueue(context.Background(), actionGroup).WaitForResult()
+		require.NoError(t, result)
+		require.Equal(t, len(didRunActionChan), expectedActionsExecuted)
+	})
+
+	t.Run("EnsureActionGroupContextCancelPropagatesToOtherContexts", func(t *testing.T) {
+		saq := re_util.NewSharedActionQueue(2)
+		actionGroup := re_util.ActionGroup{}
+		expectedActionsExecuted := 3
+		didRunActionChan := make(chan struct{}, expectedActionsExecuted)
+		innerActionStartedChan := make(chan struct{})
+		actionGroup = append(actionGroup, func(ac *re_util.ActionContext) {
+			didRunActionChan <- struct{}{}
+			actionGroup2 := re_util.ActionGroup{}
+			doneHandler := ac.Defer()
+			go func() {
+				actionGroup2 = append(actionGroup2, func(ac *re_util.ActionContext) {
+					innerActionStartedChan <- struct{}{}
+					didRunActionChan <- struct{}{}
+					ac.Done(errors.New("SomeError2"))
+				})
+				err := saq.ProcessActionQueue(ac.Ctx(), actionGroup2).WaitForResult()
+				doneHandler(err)
+			}()
+		})
+		actionGroup = append(actionGroup, func(ac *re_util.ActionContext) {
+			didRunActionChan <- struct{}{}
+			<-innerActionStartedChan // Wait for inner action to start.
+			<-ac.Ctx().Done()        // Wait for context to be canceled.
+			ac.Done(errors.New("WeGotCancelledOtherErrorShouldBeTheVisibleError"))
+		})
+		result := saq.ProcessActionQueue(context.Background(), actionGroup).WaitForResult()
+		require.EqualError(t, result, "SomeError2")
+		require.Equal(t, len(didRunActionChan), expectedActionsExecuted)
+	})
+}


### PR DESCRIPTION
Enables the ability to multiplex downloading of files/folders
by introducing SharedActionQueue utility that acts similar
to a promise/future, but more specialized for thread pools.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/buildbarn/bb-remote-execution/50)
<!-- Reviewable:end -->
