### PR TITLE
Create bb-runner-installer image

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -68,6 +68,8 @@ jobs:
         DOCKER_CONFIG_JSON: ${{ secrets.DOCKER_CONFIG_JSON }}
     - name: Push container bb-runner-ubuntu16-04
       run: bazel run //cmd/bb_runner:bb_runner_ubuntu16_04_container_push
+    - name: Push container bb-runner-installer
+      run: bazel run //cmd/bb_runner:bb_runner_installer_push
     - name: Push container bb-scheduler
       run: bazel run //cmd/bb_scheduler:bb_scheduler_container_push
     - name: Push container bb-worker

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -67,7 +67,7 @@ container_pull(
 
 container_pull(
     name = "busybox",
-    digest = "sha256:a2490cec4484ee6c1068ba3a05f89934010c85242f736280b35343483b2264b6", # 1.31.1-uclibc
+    digest = "sha256:a2490cec4484ee6c1068ba3a05f89934010c85242f736280b35343483b2264b6",  # 1.31.1-uclibc
     registry = "docker.io",
     repository = "library/busybox",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -65,6 +65,13 @@ container_pull(
     repository = "google/rbe-ubuntu16-04",
 )
 
+container_pull(
+    name = "busybox",
+    digest = "sha256:a2490cec4484ee6c1068ba3a05f89934010c85242f736280b35343483b2264b6", # 1.31.1-uclibc
+    registry = "docker.io",
+    repository = "library/busybox",
+)
+
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()

--- a/cmd/bb_runner/BUILD.bazel
+++ b/cmd/bb_runner/BUILD.bazel
@@ -54,8 +54,8 @@ container_layer(
 container_image(
     name = "bb_runner_installer",
     base = "@busybox//image",
-    entrypoint = ["/install"],
     cmd = ["/bb"],
+    entrypoint = ["/install"],
     layers = [
         ":install_layer",
         ":bb_runner_layer",

--- a/cmd/bb_runner/BUILD.bazel
+++ b/cmd/bb_runner/BUILD.bazel
@@ -46,6 +46,24 @@ container_layer(
     files = ["@com_github_krallin_tini_tini_static_amd64//file"],
 )
 
+container_layer(
+    name = "install_layer",
+    files = ["install"],
+)
+
+container_image(
+    name = "bb_runner_installer",
+    base = "@busybox//image",
+    entrypoint = ["/install"],
+    cmd = ["/bb"],
+    layers = [
+        ":install_layer",
+        ":bb_runner_layer",
+        ":tini_layer",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 container_image(
     name = "bb_runner_ubuntu16_04_container",
     base = "@rbe_ubuntu16_04_base//image",
@@ -69,4 +87,10 @@ container_push_official(
     name = "bb_runner_ubuntu16_04_container_push",
     component = "bb-runner-ubuntu16-04",
     image = ":bb_runner_ubuntu16_04_container",
+)
+
+container_push_official(
+    name = "bb_runner_installer_push",
+    component = "bb-runner-installer",
+    image = ":bb_runner_installer",
 )

--- a/cmd/bb_runner/install
+++ b/cmd/bb_runner/install
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -eu
+
+echo "$*"
+
+# Can pass the destination directory as the first argument. By default
+# it will use /bb
+dest="${1:-/bb}"
+
+cp /bb_runner /tini "$dest"


### PR DESCRIPTION
This image is for use as an init container on kubernetes, to allow
bb-runner to be used as a mixin to existing containers. Notably, this
allows users to pick any RBE image version, not just the one which
bb-remote-execution is currently selecting.

This turns out to be important bacause bazel-toolchains selects image
versions based on the version of bazel being run, and there is no
image which is compatible with all bazel versions.