### PR TITLE
Allow setting of file mtimes

### DIFF
--- a/cmd/bb_worker/main.go
+++ b/cmd/bb_worker/main.go
@@ -145,6 +145,7 @@ func main() {
 				cacheDirectory,
 				int(nativeConfiguration.MaximumCacheFileCount),
 				nativeConfiguration.MaximumCacheSizeBytes,
+				nativeConfiguration.DeterministicMtimes,
 				eviction.NewMetricsSet(evictionSet, "HardlinkingContentAddressableStorage"))
 		default:
 			log.Fatal("No build directory specified")

--- a/pkg/cas/BUILD.bazel
+++ b/pkg/cas/BUILD.bazel
@@ -16,5 +16,6 @@ go_library(
         "@com_github_buildbarn_bb_storage//pkg/eviction:go_default_library",
         "@com_github_buildbarn_bb_storage//pkg/filesystem:go_default_library",
         "@com_github_buildbarn_bb_storage//pkg/proto/cas:go_default_library",
+        "@org_golang_x_sys//unix:go_default_library",
     ],
 )

--- a/pkg/proto/configuration/bb_worker/bb_worker.proto
+++ b/pkg/proto/configuration/bb_worker/bb_worker.proto
@@ -82,6 +82,10 @@ message NativeBuildDirectoryConfiguration {
   // LEAST_RECENTLY_USED can, assuming the cache size is sufficient.
   buildbarn.configuration.eviction.CacheReplacementPolicy
       cache_replacement_policy = 5;
+
+  // Whether to set the mtimes of all of the files in the build
+  // directory to the same fixed value (2011-11-11 11:11:11).
+  bool deterministic_mtimes = 6;
 }
 
 message RunnerConfiguration {


### PR DESCRIPTION
Add option to set mtimes of all files to 2011-11-11 11:11:11 when they are hardlinked into the build directory.

Requires buildbarn/bb-storage#60 in order to work.