### PR TITLE
Allow a nil platform message

### DIFF
--- a/pkg/builder/in_memory_build_queue.go
+++ b/pkg/builder/in_memory_build_queue.go
@@ -778,7 +778,7 @@ func (k *platformKey) getPlatform() *remoteexecution.Platform {
 func newPlatformKey(instanceName string, platform *remoteexecution.Platform) (platformKey, error) {
 	// Ensure that the platform properties are in normal form.
 	if platform == nil {
-		return platformKey{}, status.Error(codes.InvalidArgument, "Platform message not set")
+		platform = &remoteexecution.Platform{}
 	}
 	properties := platform.Properties
 	for i := 1; i < len(properties); i++ {


### PR DESCRIPTION
This makes the scheduler allow commands to not specify a platform
message, and it will interpret the lack of platform message in the same
way as an empty list of key/value pairs