### PR TITLE
bb_worker: wait for bb_scheduler to be ready before initialising

### DIFF
--- a/cmd/bb_scheduler/main.go
+++ b/cmd/bb_scheduler/main.go
@@ -94,6 +94,9 @@ func main() {
 			bb_grpc.NewGRPCServersFromConfigurationAndServe(
 				configuration.WorkerGrpcServers,
 				func(s *grpc.Server) {
+					// So workers can check if we're ready:
+					remoteexecution.RegisterCapabilitiesServer(s, buildQueue)
+
 					remoteworker.RegisterOperationQueueServer(s, buildQueue)
 				}))
 	}()

--- a/cmd/bb_worker/BUILD.bazel
+++ b/cmd/bb_worker/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/proto/runner:go_default_library",
         "//pkg/runner:go_default_library",
         "//pkg/sync:go_default_library",
+        "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_buildbarn_bb_storage//pkg/blobstore:go_default_library",
         "@com_github_buildbarn_bb_storage//pkg/blobstore/configuration:go_default_library",
         "@com_github_buildbarn_bb_storage//pkg/cas:go_default_library",
@@ -30,6 +31,7 @@ go_library(
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@com_github_gorilla_mux//:go_default_library",
         "@io_bazel_rules_go//proto/wkt:empty_go_proto",
+        "@org_golang_google_grpc//:go_default_library",
         "@org_golang_x_sys//unix:go_default_library",
     ],
 )


### PR DESCRIPTION
This change makes bb_worker wait for bb_scheduler to be ready for up to 10s before it continues initialisation. This should avoid most "Failed to synchronize with scheduler" warnings at startup.

We check for readiniess by using the Capabilities service as a simple "ping" with no side effects.