### PR TITLE
Add trace span details

### DIFF
--- a/pkg/builder/build_client.go
+++ b/pkg/builder/build_client.go
@@ -94,7 +94,9 @@ func (bc *BuildClient) startExecution(executionRequest *remoteworker.DesiredStat
 			trace.BoolAttribute("cached", response.CachedResult),
 			trace.StringAttribute("message", response.Message),
 		)
-		span.SetStatus(trace.Status{Code: response.Status.Code, Message: response.Status.Message})
+		if response.Status != nil {
+			span.SetStatus(trace.Status{Code: response.Status.Code, Message: response.Status.Message})
+		}
 
 		updates <- &remoteworker.CurrentState_Executing{
 			ActionDigest: executionRequest.ActionDigest,


### PR DESCRIPTION
This inserts trace spans for the waitExecution stream, and annotates
the Execution spans with the details of what happened.

Annotating with response.Message in particularly powerful here because
that happens to contain the bb-browser URL corresponding to the
execution, which is sufficient to explore the details of the
execution. The rest of the attributes are primarily useful for
searching for the right trace.