### PR TITLE
Schedule actions based on invocation id, with web view

### DIFF
--- a/cmd/bb_scheduler/main.go
+++ b/cmd/bb_scheduler/main.go
@@ -77,6 +77,8 @@ func main() {
 			},
 			WorkerOperationRetryCount:           9,
 			WorkerWithNoSynchronizationsTimeout: time.Minute,
+			InvocationInfoTimeout:               60 * time.Minute,
+			RemoteExecutionMetadataKeys:         configuration.Keywords,
 		},
 		int(configuration.MaximumMessageSizeBytes))
 

--- a/pkg/builder/BUILD.bazel
+++ b/pkg/builder/BUILD.bazel
@@ -56,6 +56,7 @@ go_library(
         "@io_opencensus_go//trace:go_default_library",
         "@io_opencensus_go//trace/propagation:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//metadata:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
     ],
 )
@@ -103,6 +104,7 @@ go_test(
         "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//metadata:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
         "@org_golang_google_grpc//test/bufconn:go_default_library",
     ],

--- a/pkg/builder/build_queue_state_provider.go
+++ b/pkg/builder/build_queue_state_provider.go
@@ -14,7 +14,9 @@ type BuildQueueStateProvider interface {
 	GetBuildQueueState() *BuildQueueState
 	GetDetailedOperationState(name string) (*DetailedOperationState, bool)
 	KillOperation(name string) bool
-	ListDetailedOperationState(pageSize int, startAfterOperation *string) ([]DetailedOperationState, PaginationInfo)
+	KillInvocation(invocationID string) bool
+	ListDetailedOperationState(invocationID *string, selection *string, pageSize int, startAfterOperation *string) ([]DetailedOperationState, PaginationInfo, error)
+	ListInvocations(instanceName digest.InstanceName, pageSize int, active bool) ([]InvocationEntry, PaginationInfo, error)
 	ListQueuedOperationState(instanceName digest.InstanceName, platform *remoteexecution.Platform, pageSize int, startAfterPriority *int32, startAfterQueuedTimestamp *time.Time) ([]QueuedOperationState, PaginationInfo, error)
 	ListWorkerState(instanceName digest.InstanceName, platform *remoteexecution.Platform, justExecutingWorkers bool, pageSize int, startAfterWorkerID map[string]string) ([]WorkerState, PaginationInfo, error)
 
@@ -47,6 +49,7 @@ type PlatformQueueState struct {
 	Platform     remoteexecution.Platform
 
 	Timeout               *time.Time
+	InvocationCount       int
 	QueuedOperationsCount int
 	WorkersCount          int
 	ExecutingWorkersCount int
@@ -70,6 +73,19 @@ type QueuedOperationState struct {
 	BasicOperationState
 
 	Priority int32
+}
+
+// InvocationEntry contains properties of recent invocation.
+type InvocationEntry struct {
+	Priority                 int32
+	InvocationID             string
+	InvocationTimestamp      time.Time
+	InvocationTimeout        time.Time
+	QueuedOperationsCount    int
+	ExecutingOperationsCount int
+	FinishedOperationsCount  int
+	Canceled                 bool
+	Keywords                 map[string]string
 }
 
 // DetailedOperationState contains properties of an operation that is

--- a/pkg/proto/configuration/bb_scheduler/bb_scheduler.proto
+++ b/pkg/proto/configuration/bb_scheduler/bb_scheduler.proto
@@ -46,6 +46,9 @@ message ApplicationConfiguration {
 
   // AWS access options and credentials.
   buildbarn.configuration.cloud.aws.SessionConfiguration aws_session = 10;
+
+  // Keywords to display in web view
+  repeated string keywords = 11;
 }
 
 message AWSASGLifecycleHookConfiguration {


### PR DESCRIPTION
 (implements #38 and #39)
Do group actions based on their invocation ID, to improve flow of invocations.

If having same priority, operations that are queued are sorted
by invocation timestamp before queued timestamp.

Clean up invocation information after a configurable timeframe.

Invocations may share an operation. Keep a list  of connected invocations
in an operation, so that it wont be canceled until all connected invocations
are canceled.

Added invocation count on "Buildbarn Scheduler" view.

Added invocation ID on one operation's view.

Added a view where all invocations can be seen with their current state.
This include a Cancel button (that is enabled unless the invocation has
been canceled). This button will cancel any queued operations, and
also cancel any future operations for this invocation.

Support click on value in many columns in the invocations view.

Add a possibility to configure 'keywords' in bb_scheduler configuration.
This is a list of strings.
E.g.
  keywords: ["host", "user"],
These keywords will be shown in the web view if present in the invocation.
(Bazel client: --remote_exec_header="key=value")

Priority shown in web view. It is possible to specify priority by using 
the --remote_execution_priority=<value> in the bazel call.

Unit test added:
 - that test that invocation timestamp does affect sort order
 - that list of invocations work

Here is an example on how the view looks, in case keywords has been configured (in this case to host and user). The later started invocation has been canceled. 60 seconds (configurable) the last action has completed, the invocation is "moved" to the inactive view. And when Timeout (configured to 60 minutes here) the invocation is cleaned up.
![image](https://user-images.githubusercontent.com/2631151/94605929-0fe7ca00-029a-11eb-9f9c-44af2b6e571a.png)
