### PR TITLE
Add support for compiling on 32-bit systems

### DIFF
--- a/cmd/bb_worker/main.go
+++ b/cmd/bb_worker/main.go
@@ -77,7 +77,7 @@ func main() {
 			log.Fatal("Failed to open file pool block device: ", err)
 		}
 		if sectorCount > math.MaxUint32 {
-			log.Fatal("File pool block device has %d sectors, while only %d may be addressed", sectorCount, math.MaxUint32)
+			log.Fatal("File pool block device has %d sectors, while only %d may be addressed", sectorCount, uint64(math.MaxUint32))
 		}
 		filePool = re_filesystem.NewBlockDeviceBackedFilePool(
 			blockDevice,

--- a/pkg/runner/local_runner_unix.go
+++ b/pkg/runner/local_runner_unix.go
@@ -65,7 +65,7 @@ func (r *localRunner) openLog(logPath string) (filesystem.FileAppender, error) {
 
 func convertTimeval(t syscall.Timeval) *duration.Duration {
 	return &duration.Duration{
-		Seconds: t.Sec,
+		Seconds: int64(t.Sec),
 		Nanos:   int32(t.Usec) * 1000,
 	}
 }
@@ -134,17 +134,17 @@ func (r *localRunner) Run(ctx context.Context, request *runner.RunRequest) (*run
 	posixResourceUsage, err := ptypes.MarshalAny(&resourceusage.POSIXResourceUsage{
 		UserTime:                   convertTimeval(rusage.Utime),
 		SystemTime:                 convertTimeval(rusage.Stime),
-		MaximumResidentSetSize:     rusage.Maxrss * maximumResidentSetSizeUnit,
-		PageReclaims:               rusage.Minflt,
-		PageFaults:                 rusage.Majflt,
-		Swaps:                      rusage.Nswap,
-		BlockInputOperations:       rusage.Inblock,
-		BlockOutputOperations:      rusage.Oublock,
-		MessagesSent:               rusage.Msgsnd,
-		MessagesReceived:           rusage.Msgrcv,
-		SignalsReceived:            rusage.Nsignals,
-		VoluntaryContextSwitches:   rusage.Nvcsw,
-		InvoluntaryContextSwitches: rusage.Nivcsw,
+		MaximumResidentSetSize:     int64(rusage.Maxrss) * maximumResidentSetSizeUnit,
+		PageReclaims:               int64(rusage.Minflt),
+		PageFaults:                 int64(rusage.Majflt),
+		Swaps:                      int64(rusage.Nswap),
+		BlockInputOperations:       int64(rusage.Inblock),
+		BlockOutputOperations:      int64(rusage.Oublock),
+		MessagesSent:               int64(rusage.Msgsnd),
+		MessagesReceived:           int64(rusage.Msgrcv),
+		SignalsReceived:            int64(rusage.Nsignals),
+		VoluntaryContextSwitches:   int64(rusage.Nvcsw),
+		InvoluntaryContextSwitches: int64(rusage.Nivcsw),
 	})
 	if err != nil {
 		return nil, util.StatusWrap(err, "Failed to marshal POSIX resource usage")

--- a/pkg/runner/processtablecleaning/system_process_table_linux.go
+++ b/pkg/runner/processtablecleaning/system_process_table_linux.go
@@ -49,7 +49,7 @@ func (pt systemProcessTable) GetProcesses() ([]Process, error) {
 		processes = append(processes, Process{
 			ProcessID:    int(pid),
 			UserID:       int(stat.Uid),
-			CreationTime: time.Unix(stat.Ctim.Sec, stat.Ctim.Nsec),
+			CreationTime: time.Unix(int64(stat.Ctim.Sec), int64(stat.Ctim.Nsec)),
 		})
 	}
 	return processes, nil


### PR DESCRIPTION
A few explicit casts are needed in order to get the
complete buildbarn code to compile on 32-bit systems.

This makes it possible to e.g compile and execute buildbarn
on raspberry pi:s running on 32-bit kernels.