### PR TITLE
Move bb storage to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace github.com/gordonklaus/ineffassign => github.com/gordonklaus/ineffassign
 require (
 	github.com/aws/aws-sdk-go v1.37.28
 	github.com/bazelbuild/remote-apis v0.0.0-20210309154856-0943dc4e70e1
-	github.com/buildbarn/bb-storage v0.0.0-20210311095322-ee65b012ed13
+	github.com/buildbarn/bb-storage v0.0.0-20210312082612-b15cd2841ed1
 	github.com/golang/protobuf v1.4.3
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,7 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/buildbarn/bb-storage v0.0.0-20210311095322-ee65b012ed13 h1:4qFNCIy/VM3qfYilX+O4nE8Lm5pjSjvtiJvJlZMY2uo=
 github.com/buildbarn/bb-storage v0.0.0-20210311095322-ee65b012ed13/go.mod h1:cKr3o2BPePMTiy7rHT6l2h4D3rE/usn79wmMRATC36k=
+github.com/buildbarn/bb-storage v0.0.0-20210312082612-b15cd2841ed1/go.mod h1:cKr3o2BPePMTiy7rHT6l2h4D3rE/usn79wmMRATC36k=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1 h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=

--- a/go_dependencies.bzl
+++ b/go_dependencies.bzl
@@ -101,8 +101,8 @@ def go_dependencies():
     go_repository(
         name = "com_github_buildbarn_bb_storage",
         importpath = "github.com/buildbarn/bb-storage",
-        sum = "h1:4qFNCIy/VM3qfYilX+O4nE8Lm5pjSjvtiJvJlZMY2uo=",
-        version = "v0.0.0-20210311095322-ee65b012ed13",
+        sum = "h1:I/EDmu3NwBsCcv+50MkSd+J1v2Q7yC09UWiZicOsiTk=",
+        version = "v0.0.0-20210312082612-b15cd2841ed1",
     )
     go_repository(
         name = "com_github_burntsushi_toml",


### PR DESCRIPTION
I'm looking to take advantage of https://github.com/buildbarn/bb-storage/commit/b15cd2841ed1fc835886b1589151a054220ef1d0#diff-01d85776579e6a82da2d7ecfb3fcc512dd157c8d6cc23cc26d52a12fdd30fbb7
debugging a deployment.