### PR TITLE
Add environment variables to worker config

### DIFF
--- a/cmd/bb_worker/main.go
+++ b/cmd/bb_worker/main.go
@@ -265,11 +265,7 @@ func main() {
 						log.Fatal("Failed to marshal worker ID: ", err)
 					}
 
-					env := map[string]string{}
-					for k, v := range runnerConfiguration.EnvironmentVariables {
-						env[k] = v
-					}
-
+					env := runnerConfiguration.EnvironmentVariables
 					buildExecutor := builder.NewMetricsBuildExecutor(
 						builder.NewFilePoolStatsBuildExecutor(
 							builder.NewTimestampedBuildExecutor(

--- a/cmd/bb_worker/main.go
+++ b/cmd/bb_worker/main.go
@@ -265,6 +265,11 @@ func main() {
 						log.Fatal("Failed to marshal worker ID: ", err)
 					}
 
+					env := map[string]string{}
+					for k, v := range runnerConfiguration.EnvironmentVariables {
+						env[k] = v
+					}
+
 					buildExecutor := builder.NewMetricsBuildExecutor(
 						builder.NewFilePoolStatsBuildExecutor(
 							builder.NewTimestampedBuildExecutor(
@@ -277,7 +282,8 @@ func main() {
 										defaultExecutionTimeout,
 										maximumExecutionTimeout,
 										inputRootCharacterDevices,
-										int(configuration.MaximumMessageSizeBytes)),
+										int(configuration.MaximumMessageSizeBytes),
+										env),
 									contentAddressableStorageFlusher),
 								clock.SystemClock,
 								string(workerName))))

--- a/pkg/builder/local_build_executor.go
+++ b/pkg/builder/local_build_executor.go
@@ -68,11 +68,12 @@ type localBuildExecutor struct {
 	maximumExecutionTimeout   time.Duration
 	inputRootCharacterDevices map[path.Component]int
 	maximumMessageSizeBytes   int
+	environmentVariables      map[string]string
 }
 
 // NewLocalBuildExecutor returns a BuildExecutor that executes build
 // steps on the local system.
-func NewLocalBuildExecutor(contentAddressableStorage blobstore.BlobAccess, buildDirectoryCreator BuildDirectoryCreator, runner runner.Runner, clock clock.Clock, defaultExecutionTimeout, maximumExecutionTimeout time.Duration, inputRootCharacterDevices map[path.Component]int, maximumMessageSizeBytes int) BuildExecutor {
+func NewLocalBuildExecutor(contentAddressableStorage blobstore.BlobAccess, buildDirectoryCreator BuildDirectoryCreator, runner runner.Runner, clock clock.Clock, defaultExecutionTimeout, maximumExecutionTimeout time.Duration, inputRootCharacterDevices map[path.Component]int, maximumMessageSizeBytes int, environmentVariables map[string]string) BuildExecutor {
 	return &localBuildExecutor{
 		contentAddressableStorage: contentAddressableStorage,
 		buildDirectoryCreator:     buildDirectoryCreator,
@@ -82,6 +83,7 @@ func NewLocalBuildExecutor(contentAddressableStorage blobstore.BlobAccess, build
 		maximumExecutionTimeout:   maximumExecutionTimeout,
 		inputRootCharacterDevices: inputRootCharacterDevices,
 		maximumMessageSizeBytes:   maximumMessageSizeBytes,
+		environmentVariables:      environmentVariables,
 	}
 }
 
@@ -243,6 +245,9 @@ func (be *localBuildExecutor) Execute(ctx context.Context, filePool re_filesyste
 	ctxWithTimeout, cancelTimeout := be.clock.NewContextWithTimeout(ctxWithIOError, executionTimeout)
 	defer cancelTimeout()
 	environmentVariables := map[string]string{}
+	for name, value := range be.environmentVariables {
+		environmentVariables[name] = value
+	}
 	for _, environmentVariable := range command.EnvironmentVariables {
 		environmentVariables[environmentVariable.Name] = environmentVariable.Value
 	}

--- a/pkg/proto/configuration/bb_worker/bb_worker.proto
+++ b/pkg/proto/configuration/bb_worker/bb_worker.proto
@@ -153,4 +153,7 @@ message RunnerConfiguration {
   // auxiliary_metadata.
   map<string, buildbarn.resourceusage.MonetaryResourceUsage.Expense>
       costs_per_second = 10;
+
+  // Additional environment variables to set inside the runner
+  map<string, string> environment_variables = 11;
 }

--- a/pkg/proto/configuration/bb_worker/bb_worker.proto
+++ b/pkg/proto/configuration/bb_worker/bb_worker.proto
@@ -154,6 +154,7 @@ message RunnerConfiguration {
   map<string, buildbarn.resourceusage.MonetaryResourceUsage.Expense>
       costs_per_second = 10;
 
-  // Additional environment variables to set inside the runner
+  // Additional environment variables to set inside the runner.  These are
+  // overridden by environment specified in an action.
   map<string, string> environment_variables = 11;
 }

--- a/pkg/proto/configuration/bb_worker/bb_worker.proto
+++ b/pkg/proto/configuration/bb_worker/bb_worker.proto
@@ -155,6 +155,10 @@ message RunnerConfiguration {
       costs_per_second = 10;
 
   // Additional environment variables to set inside the runner.  These are
-  // overridden by environment specified in an action.
+  // overridden by environment specified in an action.  For better hermeticity,
+  // is preferable to have the environment controlled by the build client, such
+  // as Bazel's --action_env.  --action_env, however, has limited scope that
+  // makes it not useful in some scenarios:
+  // https://github.com/bazelbuild/bazel/issues/3320
   map<string, string> environment_variables = 11;
 }


### PR DESCRIPTION
Allows adding env vars to those given by the action.

This is needed for the xcode toolchain, because the clang wrapper used by bazel depends on two variables, DEVELOPER_DIR and SDKROOT, to locate the correct toolchain to use.  These are set beneath the main action layer (they aren't reported for instance when you do `bazel build ... -s`).  I believe the behavior must be implemented somewhere in buildbarn because:
1. `--action_env` rather comically doesn't actually apply to most actions (bazelbuild/bazel#3320).  Notably in my case it wasn't passed to cc linking actions.
2. The runner (correctly, in my opinion) does not pass on its surrounding environment to the actions it spawns, so I can't set these before running bb_runner.

I put the specification in bb_worker's RunnerConfiguration because it was close in proximity to the platform config, which the variables are likely to relate to (e.g. add variables to support a particular toolchain advertised by Platform).  But there are probably other places they could go too.  As it exists now, these variables are overridden by anything specified in the action's env, but I could see potential use cases for wanting to specifically prepend/append to `PATH`.

I think I saw a conversation in slack that was not enthusiastic about carrying these inside bb, but didn't really see another viable option (and this is roughly what I recall buildfarm recommending)