### PR TITLE
Log stdout/stderr paths when bb_runner fails to open them

### DIFF
--- a/pkg/runner/local_runner_test.go
+++ b/pkg/runner/local_runner_test.go
@@ -183,7 +183,7 @@ func TestLocalRunner(t *testing.T) {
 		require.Equal(
 			t,
 			err,
-			status.Error(codes.InvalidArgument, "Failed to open stdout: Path resolves to a location outside the build directory"))
+			status.Error(codes.InvalidArgument, "Failed to open stdout path \"hello/../../../../../../etc/passwd\": Path resolves to a location outside the build directory"))
 	})
 
 	// TODO: Improve testing coverage of LocalRunner.

--- a/pkg/runner/local_runner_unix.go
+++ b/pkg/runner/local_runner_unix.go
@@ -162,14 +162,14 @@ func (r *localRunner) Run(ctx context.Context, request *runner.RunRequest) (*run
 	// Open output files for logging.
 	stdout, err := r.openLog(request.StdoutPath)
 	if err != nil {
-		return nil, util.StatusWrap(err, "Failed to open stdout")
+		return nil, util.StatusWrapf(err, "Failed to open stdout path %q", request.StdoutPath)
 	}
 	cmd.Stdout = stdout
 
 	stderr, err := r.openLog(request.StderrPath)
 	if err != nil {
 		stdout.Close()
-		return nil, util.StatusWrap(err, "Failed to open stderr")
+		return nil, util.StatusWrapf(err, "Failed to open stderr path %q", request.StderrPath)
 	}
 	cmd.Stderr = stderr
 


### PR DESCRIPTION
This might help users debugging this kind of failure.