### PR TITLE
Add support for compiling on Apple M1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -169,7 +169,11 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/3.7.0/rules_nodejs-3.7.0.tar.gz"],
 )
 
-load("@build_bazel_rules_nodejs//:index.bzl", "npm_install")
+load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "npm_install")
+
+node_repositories(
+    node_version = "16.4.1",
+)
 
 npm_install(
     name = "npm",


### PR DESCRIPTION
Same change as made for bb-storage for adding support for darwin_arm64

The node package supports darwin_arm64 from version 16+ so this PR will increment the node_version
to the latest supported version by the currently pointed out rules_nodejs.
