### PR TITLE
Allow users of NewMountFromConfiguration to unmount cleanly

### DIFF
--- a/cmd/bb_worker/main.go
+++ b/cmd/bb_worker/main.go
@@ -156,7 +156,7 @@ func main() {
 				}
 				return nil
 			}
-			if err := re_fuse.NewMountFromConfiguration(
+			if _, err := re_fuse.NewMountFromConfiguration(
 				backend.Fuse.Mount,
 				fuseBuildDirectory,
 				rootInodeNumber,

--- a/pkg/filesystem/fuse/fuse_disabled.go
+++ b/pkg/filesystem/fuse/fuse_disabled.go
@@ -34,6 +34,10 @@ type PrepopulatedDirectory interface {
 
 type SimpleRawFileSystemServerCallbacks struct{}
 
+type Server interface {
+	Unmount() error
+}
+
 func (sc *SimpleRawFileSystemServerCallbacks) EntryNotify() {
 	panic("FUSE is not supported on this platform")
 }
@@ -42,8 +46,8 @@ func NewInMemoryPrepopulatedDirectory(fileAllocator FileAllocator, errorLogger u
 	return nil
 }
 
-func NewMountFromConfiguration(configuration *pb.MountConfiguration, rootDirectory Directory, rootDirectoryInodeNumber uint64, serverCallbacks *SimpleRawFileSystemServerCallbacks, fsName string) error {
-	return status.Error(codes.Unimplemented, "FUSE is not supported on this platform")
+func NewMountFromConfiguration(configuration *pb.MountConfiguration, rootDirectory Directory, rootDirectoryInodeNumber uint64, serverCallbacks *SimpleRawFileSystemServerCallbacks, fsName string) (Server, error) {
+	return nil, status.Error(codes.Unimplemented, "FUSE is not supported on this platform")
 }
 
 func NewPoolBackedFileAllocator(pool re_filesystem.FilePool, errorLogger util.ErrorLogger, inodeNumberGenerator random.ThreadSafeGenerator) FileAllocator {


### PR DESCRIPTION
Allow users of NewMountFromConfiguration to cleanly unmount the FUSE
filesystem before process exit, by returning a Server interface to the
caller.