### PR TITLE
Upgrade to Go 1.18

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -29,7 +29,7 @@
             },
             {
                "name": "Gofmt",
-               "run": "bazel run @cc_mvdan_gofumpt//:gofumpt -- -lang 1.17 -w -extra $(pwd)"
+               "run": "bazel run @cc_mvdan_gofumpt//:gofumpt -- -lang 1.18 -w -extra $(pwd)"
             },
             {
                "name": "Clang format",

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -29,7 +29,7 @@
             },
             {
                "name": "Gofmt",
-               "run": "bazel run @cc_mvdan_gofumpt//:gofumpt -- -lang 1.17 -w -extra $(pwd)"
+               "run": "bazel run @cc_mvdan_gofumpt//:gofumpt -- -lang 1.18 -w -extra $(pwd)"
             },
             {
                "name": "Clang format",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,7 +48,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.17.2")
+go_register_toolchains(version = "1.18")
 
 load("@io_bazel_rules_docker//repositories:repositories.bzl", container_repositories = "repositories")
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildbarn/bb-remote-execution
 
-go 1.17
+go 1.18
 
 // Use the same version as in bb-storage.
 replace github.com/gordonklaus/ineffassign => github.com/gordonklaus/ineffassign v0.0.0-20201223204552-cba2d2a1d5d9
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.18.0
 	github.com/aws/smithy-go v1.11.1
 	github.com/bazelbuild/remote-apis v0.0.0-20220223171137-04784f4a830c
-	github.com/buildbarn/bb-storage v0.0.0-20220316134132-d293162d3381
+	github.com/buildbarn/bb-storage v0.0.0-20220316195748-251ae686ce20
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/buildbarn/bb-storage v0.0.0-20220316134132-d293162d3381 h1:3k7HXf/neqR+lY9trzNnUXU6Xx+9LD9F75Dwbdki3MU=
-github.com/buildbarn/bb-storage v0.0.0-20220316134132-d293162d3381/go.mod h1:T5lnXHVYHk6x2+w6futgBn6TMAXUl7uJpZ/IXYR+unU=
+github.com/buildbarn/bb-storage v0.0.0-20220316195748-251ae686ce20 h1:Z/L1vAx2b8fdDlP7459uvf84zoNgttF7cMVZuR9LdwY=
+github.com/buildbarn/bb-storage v0.0.0-20220316195748-251ae686ce20/go.mod h1:prAd3v0rqcVFP2fzVrvzh5N5x3OitwcEiyiVoBTleN4=
 github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/go_dependencies.bzl
+++ b/go_dependencies.bzl
@@ -156,8 +156,8 @@ def go_dependencies():
     go_repository(
         name = "com_github_buildbarn_bb_storage",
         importpath = "github.com/buildbarn/bb-storage",
-        sum = "h1:3k7HXf/neqR+lY9trzNnUXU6Xx+9LD9F75Dwbdki3MU=",
-        version = "v0.0.0-20220316134132-d293162d3381",
+        sum = "h1:Z/L1vAx2b8fdDlP7459uvf84zoNgttF7cMVZuR9LdwY=",
+        version = "v0.0.0-20220316195748-251ae686ce20",
     )
     go_repository(
         name = "com_github_burntsushi_toml",

--- a/pkg/builder/completed_action_logger_test.go
+++ b/pkg/builder/completed_action_logger_test.go
@@ -47,11 +47,9 @@ func TestRemoteCompletedActionLogger(t *testing.T) {
 	}
 
 	t.Run("OnlyRecvCallsFailure", func(t *testing.T) {
-		var savedCtx context.Context
 		clientStream := mock.NewMockClientStream(ctrl)
 		conn.EXPECT().NewStream(gomock.Any(), gomock.Any(), "/buildbarn.completedactionlogger.CompletedActionLogger/LogCompletedActions", gomock.Any()).
 			DoAndReturn(func(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-				savedCtx = ctx
 				return clientStream, nil
 			})
 

--- a/pkg/scheduler/in_memory_build_queue_test.go
+++ b/pkg/scheduler/in_memory_build_queue_test.go
@@ -3584,11 +3584,9 @@ func TestInMemoryBuildQueueIdleSynchronizingWorkers(t *testing.T) {
 		wait7 <- struct{}{}
 		return timer6, nil
 	})
-	var response4 *remoteworker.SynchronizeResponse
-	var err4 error
-	wait8 := make(chan struct{}, 1)
 	go func() {
-		response4, err4 = buildQueue.Synchronize(ctx, &remoteworker.SynchronizeRequest{
+		// This call will wait for the idle response timeout to pass.
+		buildQueue.Synchronize(ctx, &remoteworker.SynchronizeRequest{
 			WorkerId: workerID2,
 			Platform: platformForTesting,
 			CurrentState: &remoteworker.CurrentState{
@@ -3604,7 +3602,6 @@ func TestInMemoryBuildQueueIdleSynchronizingWorkers(t *testing.T) {
 				},
 			},
 		})
-		wait8 <- struct{}{}
 	}()
 	<-wait7
 


### PR DESCRIPTION
This PR also removes some unused variables in tests, as that is required by the Go 1.18 compiler.