### PR TITLE
Drop CAP_SYS_ADMIN after FUSE initialization

### DIFF
--- a/pkg/filesystem/virtual/configuration/BUILD.bazel
+++ b/pkg/filesystem/virtual/configuration/BUILD.bazel
@@ -5,6 +5,8 @@ go_library(
     srcs = [
         "attribute_caching_duration.go",
         "configuration.go",
+        "drop_capabilities_disabled.go",
+        "drop_capabilities_linux.go",
         "fuse_mount_disabled.go",
         "fuse_mount_enabled.go",
         "nfsv4_mount_darwin.go",

--- a/pkg/filesystem/virtual/configuration/drop_capabilities_disabled.go
+++ b/pkg/filesystem/virtual/configuration/drop_capabilities_disabled.go
@@ -1,0 +1,13 @@
+//go:build !linux
+// +build !linux
+
+package configuration
+
+// dropMountCapabilities removes capabilities that are needed to mount a FUSE filesystem,
+// but not needed after initialization.
+//
+// This is a placeholder implementation for operating systems other than
+// Linux.
+func dropMountCapabilities() error {
+	return nil
+}

--- a/pkg/filesystem/virtual/configuration/drop_capabilities_linux.go
+++ b/pkg/filesystem/virtual/configuration/drop_capabilities_linux.go
@@ -1,0 +1,14 @@
+//go:build linux
+// +build linux
+
+package configuration
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// dropMountCapabilities removes capabilities that are needed to mount a FUSE filesystem,
+// but not needed after initialization.
+func dropMountCapabilities() error {
+	return unix.Prctl(unix.PR_CAPBSET_DROP, 21 /* CAP_SYS_ADMIN */, 0, 0, 0)
+}

--- a/pkg/filesystem/virtual/configuration/fuse_mount_enabled.go
+++ b/pkg/filesystem/virtual/configuration/fuse_mount_enabled.go
@@ -94,5 +94,11 @@ func (m *fuseMount) Expose(terminationGroup program.Group, rootDirectory virtual
 	); err != nil {
 		return util.StatusWrap(err, "Failed to set Linux Backing Device Info tunables")
 	}
+
+	// Access to call mount() is no longer needed now that FUSE has been initialized.
+	if err := dropMountCapabilities(); err != nil {
+		return util.StatusWrap(err, "Unable to drop mount capability. You may be missing CAP_SETPCAP")
+	}
+
 	return nil
 }


### PR DESCRIPTION
Mounting a FUSE filesystem on Linux requires the CAP_SYS_ADMIN capability, which gives very broad access (see https://man7.org/linux/man-pages/man7/capabilities.7.html). Dropping CAP_SYS_ADMIN when we no longer need it should reduce the risk involved with having to grant this capability in the first place.