### PR TITLE
Copyfile hardlink fallback

### DIFF
--- a/pkg/cas/hardlinking_file_fetcher.go
+++ b/pkg/cas/hardlinking_file_fetcher.go
@@ -111,10 +111,14 @@ func (ff *hardlinkingFileFetcher) GetFile(ctx context.Context, blobDigest digest
 			return err
 		}
 
-		// Hardlink the file into the cache.
+		// Try to hardlink the file into the cache.
 		if err := directory.Link(name, ff.cacheDirectory, path.MustNewComponent(key)); err != nil && !os.IsExist(err) {
-			return util.StatusWrapfWithCode(err, codes.Internal, "Failed to add cached file %#v", key)
+			// Copy PkgInfo files to the cache directory rather than hardlinking them.
+			if err2 := directory.Clonefile(name, ff.cacheDirectory, path.MustNewComponent(key)); err2 != nil && !os.IsExist(err2) {
+				return util.StatusWrapfWithCode(err, codes.Internal, "Failed to add cached file %#v", key)
+			}
 		}
+
 		ff.evictionSet.Insert(key)
 		ff.filesSize[key] = sizeBytes
 		ff.filesTotalSize += sizeBytes

--- a/pkg/cas/hardlinking_file_fetcher.go
+++ b/pkg/cas/hardlinking_file_fetcher.go
@@ -113,7 +113,7 @@ func (ff *hardlinkingFileFetcher) GetFile(ctx context.Context, blobDigest digest
 
 		// Try to hardlink the file into the cache.
 		if err := directory.Link(name, ff.cacheDirectory, path.MustNewComponent(key)); err != nil && !os.IsExist(err) {
-			// Copy PkgInfo files to the cache directory rather than hardlinking them.
+			// Copy files to the cache directory rather than hardlinking them.
 			if err2 := directory.Clonefile(name, ff.cacheDirectory, path.MustNewComponent(key)); err2 != nil && !os.IsExist(err2) {
 				return util.StatusWrapfWithCode(err, codes.Internal, "Failed to add cached file %#v", key)
 			}

--- a/pkg/cas/hardlinking_file_fetcher.go
+++ b/pkg/cas/hardlinking_file_fetcher.go
@@ -114,7 +114,7 @@ func (ff *hardlinkingFileFetcher) GetFile(ctx context.Context, blobDigest digest
 		// Try to hardlink the file into the cache.
 		if err := directory.Link(name, ff.cacheDirectory, path.MustNewComponent(key)); err != nil && !os.IsExist(err) {
 			// Copy files to the cache directory rather than hardlinking them.
-			if err2 := directory.Clonefile(name, ff.cacheDirectory, path.MustNewComponent(key)); err2 != nil && !os.IsExist(err2) {
+			if err := directory.Clonefile(name, ff.cacheDirectory, path.MustNewComponent(key)); err != nil && !os.IsExist(err) {
 				return util.StatusWrapfWithCode(err, codes.Internal, "Failed to add cached file %#v", key)
 			}
 		}


### PR DESCRIPTION
I've found that on MacOS, hardlinking PkgInfo and lproj files does not work. This fix falls back to copy files to the cache rather than hardlinking