### PR TITLE
Make bb-runner's tini and install layers publically visible

### DIFF
--- a/cmd/bb_runner/BUILD.bazel
+++ b/cmd/bb_runner/BUILD.bazel
@@ -64,11 +64,13 @@ pkg_tar(
         ],
     }),
     tags = ["manual"],
+    visibility = ["//visibility:public"],
 )
 
 pkg_tar(
     name = "install_layer",
     srcs = ["install"],
+    visibility = ["//visibility:public"],
 )
 
 oci_image(


### PR DESCRIPTION
We want to build an image for runner-installer ourselves, but not consume the oci_image defined here. Having these layers visible, without needing to patch, would be very welcome.