### PR TITLE
Expose platform properties in scheduler metrics

### DIFF
--- a/pkg/scheduler/in_memory_build_queue.go
+++ b/pkg/scheduler/in_memory_build_queue.go
@@ -1446,7 +1446,10 @@ func (pq *platformQueue) addSizeClassQueue(bq *InMemoryBuildQueue, sizeClass uin
 		"size_class":           sizeClassStr,
 	}
 	for p, pv := range pq.properties {
-		platformLabels[p] = pv
+		// do not overwrite existing labels, in case of weirdly named properties.
+		if _, ok := platformLabels[p]; !ok {
+			platformLabels[p] = pv
+		}
 	}
 	metrics := newSizeClassQueueMetrics(platformLabels)
 	scq := &sizeClassQueue{


### PR DESCRIPTION
Currently, prometheus metrics on the scheduler report all platform properties as a json-serialized string under the "properties" label. This is useful for bb-autoscaler, which knows how to parse this value, but is very challenging to use with tooling which might already be available for autoscaling in your setup, like [keda](https://keda.sh/). It also makes it challenging to dashboard or analyze queue metrics.

This change modifies the metric reporting behavior in the scheduler, adding all entries found in the platform to the labels. Collisions are resolved with comma-delimiting the values, which will act as a consistent label due to the strict ordering on properties accepted by buildbarn. Existing labels (platform, instance_name_prefix, and size_class) are prioritized, and cannot be renamed to avoid breaking existing alerts, and to avoid interfering with bb-autoscaler.

Implementation-wise, the individual metrics have been converted to templates which are instantiated whenever a new size class queue is created. The size class queue provisions and registers a registry for its metrics, which it deregisters in its `remove` method.