### PR TITLE
Add VirtualApply(ApplyOpenReadFrozen)

### DIFF
--- a/pkg/filesystem/virtual/node.go
+++ b/pkg/filesystem/virtual/node.go
@@ -93,3 +93,21 @@ type ApplyAppendOutputPathPersistencyDirectoryNode struct {
 	Directory *outputpathpersistency.Directory
 	Name      path.Component
 }
+
+// ApplyOpenReadFrozen is an operation for VirtualApply that opens a
+// regular file for reading. The file's contents are guaranteed to be
+// immutable as long as the file is kept open.
+//
+// If the file is still opened for writing through the virtual file
+// system, implementations should wait for the file to be closed to
+// ensure that all data is flushed from the page cache. The
+// WritableFileDelay channel can be used to place a bound on the maximum
+// amount of time to wait.
+type ApplyOpenReadFrozen struct {
+	// Inputs.
+	WritableFileDelay <-chan struct{}
+
+	// Outputs.
+	Reader filesystem.FileReader
+	Err    error
+}

--- a/pkg/filesystem/virtual/pool_backed_file_allocator.go
+++ b/pkg/filesystem/virtual/pool_backed_file_allocator.go
@@ -379,6 +379,12 @@ func (f *fileBackedFile) VirtualApply(data any) bool {
 				IsExecutable: f.isExecutable,
 			})
 		}
+	case *ApplyOpenReadFrozen:
+		if frozenFile, success := f.waitAndOpenReadFrozen(p.WritableFileDelay); success {
+			p.Reader = frozenFile
+		} else {
+			p.Err = status.Error(codes.NotFound, "File was unlinked before file could be opened")
+		}
 	default:
 		return false
 	}


### PR DESCRIPTION
Right now the only way to read the contents of a pool backed file is to upload it into an REv2 CAS. Let's expose the ability to open files for reading through VirtualApply(), so that it's possible to use this logic outside the context of REv2.