### PR TITLE
Replace GetContainingDigests() with VirtualApply()

### DIFF
--- a/pkg/builder/virtual_build_directory.go
+++ b/pkg/builder/virtual_build_directory.go
@@ -140,8 +140,8 @@ func (d *virtualBuildDirectory) Lstat(name path.Component) (filesystem.FileInfo,
 }
 
 func (d *virtualBuildDirectory) Mkdir(name path.Component, mode os.FileMode) error {
-	return d.CreateChildren(map[path.Component]virtual.InitialNode{
-		name: virtual.InitialNode{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
+	return d.CreateChildren(map[path.Component]virtual.InitialChild{
+		name: virtual.InitialChild{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
 	}, false)
 }
 
@@ -150,8 +150,8 @@ func (d *virtualBuildDirectory) Mknod(name path.Component, perm os.FileMode, dev
 		return status.Error(codes.InvalidArgument, "The provided file mode is not for a character device")
 	}
 	characterDevice := d.options.characterDeviceFactory.LookupCharacterDevice(deviceNumber)
-	if err := d.CreateChildren(map[path.Component]virtual.InitialNode{
-		name: virtual.InitialNode{}.FromLeaf(characterDevice),
+	if err := d.CreateChildren(map[path.Component]virtual.InitialChild{
+		name: virtual.InitialChild{}.FromLeaf(characterDevice),
 	}, false); err != nil {
 		characterDevice.Unlink()
 		return err

--- a/pkg/filesystem/virtual/access_monitoring_initial_contents_fetcher.go
+++ b/pkg/filesystem/virtual/access_monitoring_initial_contents_fetcher.go
@@ -21,7 +21,7 @@ func NewAccessMonitoringInitialContentsFetcher(base InitialContentsFetcher, root
 	}
 }
 
-func (icf *accessMonitoringInitialContentsFetcher) FetchContents(fileReadMonitorFactory FileReadMonitorFactory) (map[path.Component]InitialNode, error) {
+func (icf *accessMonitoringInitialContentsFetcher) FetchContents(fileReadMonitorFactory FileReadMonitorFactory) (map[path.Component]InitialChild, error) {
 	// Call into underlying initial contents fetcher. Wrap the file
 	// read monitors that are installed on the files, so that we can
 	// detect file access.
@@ -43,16 +43,16 @@ func (icf *accessMonitoringInitialContentsFetcher) FetchContents(fileReadMonitor
 
 	// Wrap all of the child directories, so that we can detect
 	// directory access.
-	wrappedContents := make(map[path.Component]InitialNode, len(contents))
+	wrappedContents := make(map[path.Component]InitialChild, len(contents))
 	for name, node := range contents {
 		childInitialContentsFetcher, leaf := node.GetPair()
 		if childInitialContentsFetcher != nil {
-			wrappedContents[name] = InitialNode{}.FromDirectory(&accessMonitoringInitialContentsFetcher{
+			wrappedContents[name] = InitialChild{}.FromDirectory(&accessMonitoringInitialContentsFetcher{
 				InitialContentsFetcher: childInitialContentsFetcher,
 				unreadDirectoryMonitor: readDirectoryMonitor.ResolvedDirectory(name),
 			})
 		} else {
-			wrappedContents[name] = InitialNode{}.FromLeaf(leaf)
+			wrappedContents[name] = InitialChild{}.FromLeaf(leaf)
 		}
 	}
 	return wrappedContents, nil

--- a/pkg/filesystem/virtual/access_monitoring_initial_contents_fetcher_test.go
+++ b/pkg/filesystem/virtual/access_monitoring_initial_contents_fetcher_test.go
@@ -49,11 +49,11 @@ func TestAccessMonitoringInitialContentsFetcher(t *testing.T) {
 		baseFileReadMonitorFactory.EXPECT().Call(path.MustNewComponent("file")).Return(baseChildFileReadMonitor.Call)
 		var childFileReadMonitor virtual.FileReadMonitor
 		baseInitialContentsFetcher.EXPECT().FetchContents(gomock.Any()).
-			DoAndReturn(func(fileReadMonitorFactory virtual.FileReadMonitorFactory) (map[path.Component]virtual.InitialNode, error) {
+			DoAndReturn(func(fileReadMonitorFactory virtual.FileReadMonitorFactory) (map[path.Component]virtual.InitialChild, error) {
 				childFileReadMonitor = fileReadMonitorFactory(path.MustNewComponent("file"))
-				return map[path.Component]virtual.InitialNode{
-					path.MustNewComponent("dir"):  virtual.InitialNode{}.FromDirectory(baseChildInitialContentsFetcher),
-					path.MustNewComponent("file"): virtual.InitialNode{}.FromLeaf(baseChildFile),
+				return map[path.Component]virtual.InitialChild{
+					path.MustNewComponent("dir"):  virtual.InitialChild{}.FromDirectory(baseChildInitialContentsFetcher),
+					path.MustNewComponent("file"): virtual.InitialChild{}.FromLeaf(baseChildFile),
 				}, nil
 			})
 		rootReadDirectoryMonitor := mock.NewMockReadDirectoryMonitor(ctrl)
@@ -69,7 +69,7 @@ func TestAccessMonitoringInitialContentsFetcher(t *testing.T) {
 			childInitialContentsFetcher, _ := rootContents[path.MustNewComponent("dir")].GetPair()
 
 			t.Run("FetchContentsSucceeded", func(t *testing.T) {
-				baseChildInitialContentsFetcher.EXPECT().FetchContents(gomock.Any()).Return(map[path.Component]virtual.InitialNode{}, nil)
+				baseChildInitialContentsFetcher.EXPECT().FetchContents(gomock.Any()).Return(map[path.Component]virtual.InitialChild{}, nil)
 				childReadDirectoryMonitor := mock.NewMockReadDirectoryMonitor(ctrl)
 				childUnreadDirectoryMonitor.EXPECT().ReadDirectory().Return(childReadDirectoryMonitor)
 				baseChildFileReadMonitorFactory := mock.NewMockFileReadMonitorFactory(ctrl)

--- a/pkg/filesystem/virtual/cas_initial_contents_fetcher_test.go
+++ b/pkg/filesystem/virtual/cas_initial_contents_fetcher_test.go
@@ -217,11 +217,11 @@ func TestCASInitialContentsFetcherFetchContents(t *testing.T) {
 		children, err := initialContentsFetcher.FetchContents(fileReadMonitorFactory.Call)
 		require.NoError(t, err)
 		childInitialContentsFetcher, _ := children[path.MustNewComponent("directory")].GetPair()
-		require.Equal(t, map[path.Component]virtual.InitialNode{
-			path.MustNewComponent("directory"):  virtual.InitialNode{}.FromDirectory(childInitialContentsFetcher),
-			path.MustNewComponent("executable"): virtual.InitialNode{}.FromLeaf(executableLeaf),
-			path.MustNewComponent("file"):       virtual.InitialNode{}.FromLeaf(fileLeaf),
-			path.MustNewComponent("symlink"):    virtual.InitialNode{}.FromLeaf(symlinkLeaf),
+		require.Equal(t, map[path.Component]virtual.InitialChild{
+			path.MustNewComponent("directory"):  virtual.InitialChild{}.FromDirectory(childInitialContentsFetcher),
+			path.MustNewComponent("executable"): virtual.InitialChild{}.FromLeaf(executableLeaf),
+			path.MustNewComponent("file"):       virtual.InitialChild{}.FromLeaf(fileLeaf),
+			path.MustNewComponent("symlink"):    virtual.InitialChild{}.FromLeaf(symlinkLeaf),
 		}, children)
 
 		// Check that the InitialContentsFetcher that is created

--- a/pkg/filesystem/virtual/cas_initial_contents_fetcher_test.go
+++ b/pkg/filesystem/virtual/cas_initial_contents_fetcher_test.go
@@ -257,8 +257,11 @@ func TestCASInitialContentsFetcherGetContainingDigests(t *testing.T) {
 			Return(nil, status.Error(codes.Internal, "Server failure"))
 		directoryWalker.EXPECT().GetDescription().Return("Root directory")
 
-		_, err := initialContentsFetcher.GetContainingDigests(ctx)
-		testutil.RequireEqualStatus(t, status.Error(codes.Internal, "Root directory: Server failure"), err)
+		p := virtual.ApplyGetContainingDigests{
+			Context: ctx,
+		}
+		require.True(t, initialContentsFetcher.VirtualApply(&p))
+		testutil.RequireEqualStatus(t, status.Error(codes.Internal, "Root directory: Server failure"), p.Err)
 	})
 
 	t.Run("ChildDirectoryInvalidDigest", func(t *testing.T) {
@@ -277,8 +280,11 @@ func TestCASInitialContentsFetcherGetContainingDigests(t *testing.T) {
 		}, nil)
 		directoryWalker.EXPECT().GetDescription().Return("Root directory")
 
-		_, err := initialContentsFetcher.GetContainingDigests(ctx)
-		testutil.RequireEqualStatus(t, status.Error(codes.InvalidArgument, "Root directory: Failed to obtain digest for directory \"hello\": Hash has length 18, while 32 characters were expected"), err)
+		p := virtual.ApplyGetContainingDigests{
+			Context: ctx,
+		}
+		require.True(t, initialContentsFetcher.VirtualApply(&p))
+		testutil.RequireEqualStatus(t, status.Error(codes.InvalidArgument, "Root directory: Failed to obtain digest for directory \"hello\": Hash has length 18, while 32 characters were expected"), p.Err)
 	})
 
 	t.Run("ChildFileInvalidDigest", func(t *testing.T) {
@@ -297,8 +303,11 @@ func TestCASInitialContentsFetcherGetContainingDigests(t *testing.T) {
 		}, nil)
 		directoryWalker.EXPECT().GetDescription().Return("Root directory")
 
-		_, err := initialContentsFetcher.GetContainingDigests(ctx)
-		testutil.RequireEqualStatus(t, status.Error(codes.InvalidArgument, "Root directory: Failed to obtain digest for file \"hello\": Hash has length 18, while 32 characters were expected"), err)
+		p := virtual.ApplyGetContainingDigests{
+			Context: ctx,
+		}
+		require.True(t, initialContentsFetcher.VirtualApply(&p))
+		testutil.RequireEqualStatus(t, status.Error(codes.InvalidArgument, "Root directory: Failed to obtain digest for file \"hello\": Hash has length 18, while 32 characters were expected"), p.Err)
 	})
 
 	t.Run("Success", func(t *testing.T) {
@@ -357,8 +366,11 @@ func TestCASInitialContentsFetcherGetContainingDigests(t *testing.T) {
 			},
 		}, nil)
 
-		digests, err := initialContentsFetcher.GetContainingDigests(ctx)
-		require.NoError(t, err)
+		p := virtual.ApplyGetContainingDigests{
+			Context: ctx,
+		}
+		require.True(t, initialContentsFetcher.VirtualApply(&p))
+		require.NoError(t, p.Err)
 		require.Equal(
 			t,
 			digest.NewSetBuilder().
@@ -367,6 +379,6 @@ func TestCASInitialContentsFetcherGetContainingDigests(t *testing.T) {
 				Add(digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "c0607941dd5b3ca8e175a1bfbfd1c0ea", 789)).
 				Add(digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "19dc69325bd8dfcd75cefbb6144ea3bb", 42)).
 				Build(),
-			digests)
+			p.ContainingDigests)
 	})
 }

--- a/pkg/filesystem/virtual/empty_initial_contents_fetcher.go
+++ b/pkg/filesystem/virtual/empty_initial_contents_fetcher.go
@@ -9,8 +9,8 @@ import (
 
 type emptyInitialContentsFetcher struct{}
 
-func (f emptyInitialContentsFetcher) FetchContents(fileReadMonitorFactory FileReadMonitorFactory) (map[path.Component]InitialNode, error) {
-	return map[path.Component]InitialNode{}, nil
+func (f emptyInitialContentsFetcher) FetchContents(fileReadMonitorFactory FileReadMonitorFactory) (map[path.Component]InitialChild, error) {
+	return map[path.Component]InitialChild{}, nil
 }
 
 func (f emptyInitialContentsFetcher) GetContainingDigests(ctx context.Context) (digest.Set, error) {

--- a/pkg/filesystem/virtual/empty_initial_contents_fetcher.go
+++ b/pkg/filesystem/virtual/empty_initial_contents_fetcher.go
@@ -1,9 +1,6 @@
 package virtual
 
 import (
-	"context"
-
-	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/filesystem/path"
 )
 
@@ -13,8 +10,8 @@ func (f emptyInitialContentsFetcher) FetchContents(fileReadMonitorFactory FileRe
 	return map[path.Component]InitialChild{}, nil
 }
 
-func (f emptyInitialContentsFetcher) GetContainingDigests(ctx context.Context) (digest.Set, error) {
-	return digest.EmptySet, nil
+func (f emptyInitialContentsFetcher) VirtualApply(data any) bool {
+	return false
 }
 
 // EmptyInitialContentsFetcher is an instance of InitialContentsFetcher

--- a/pkg/filesystem/virtual/in_memory_prepopulated_directory.go
+++ b/pkg/filesystem/virtual/in_memory_prepopulated_directory.go
@@ -167,7 +167,7 @@ func (c *inMemoryDirectoryContents) isDeletable(hiddenFilesMatcher StringMatcher
 	return true
 }
 
-func (c *inMemoryDirectoryContents) createChildren(subtree *inMemorySubtree, children map[path.Component]InitialNode) {
+func (c *inMemoryDirectoryContents) createChildren(subtree *inMemorySubtree, children map[path.Component]InitialChild) {
 	// Either sort or shuffle the children before inserting them
 	// into the directory. This either makes VirtualReadDir() behave
 	// deterministically, or not, based on preference.
@@ -519,7 +519,7 @@ func (i *inMemoryPrepopulatedDirectory) InstallHooks(fileAllocator FileAllocator
 	}
 }
 
-func (i *inMemoryPrepopulatedDirectory) CreateChildren(children map[path.Component]InitialNode, overwrite bool) error {
+func (i *inMemoryPrepopulatedDirectory) CreateChildren(children map[path.Component]InitialChild, overwrite bool) error {
 	i.lock.Lock()
 	contents, err := i.getContents()
 	if err != nil {
@@ -598,7 +598,7 @@ func (i *inMemoryPrepopulatedDirectory) filterChildrenRecursive(childFilter Chil
 		// instantiate it. Simply provide the
 		// InitialContentsFetcher to the callback.
 		i.lock.Unlock()
-		return childFilter(InitialNode{}.FromDirectory(initialContentsFetcher), func() error {
+		return childFilter(InitialChild{}.FromDirectory(initialContentsFetcher), func() error {
 			return i.RemoveAllChildren(false)
 		})
 	}
@@ -626,7 +626,7 @@ func (i *inMemoryPrepopulatedDirectory) filterChildrenRecursive(childFilter Chil
 	// Invoke the callback for all children.
 	for _, child := range leaves {
 		name := child.name
-		if !childFilter(InitialNode{}.FromLeaf(child.leaf), func() error {
+		if !childFilter(InitialChild{}.FromLeaf(child.leaf), func() error {
 			return i.Remove(name)
 		}) {
 			return false

--- a/pkg/filesystem/virtual/in_memory_prepopulated_directory_test.go
+++ b/pkg/filesystem/virtual/in_memory_prepopulated_directory_test.go
@@ -73,8 +73,8 @@ func TestInMemoryPrepopulatedDirectoryLookupChildFile(t *testing.T) {
 	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock)
 
 	leaf := mock.NewMockLinkableLeaf(ctrl)
-	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("file"): virtual.InitialNode{}.FromLeaf(leaf),
+	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("file"): virtual.InitialChild{}.FromLeaf(leaf),
 	}, false))
 
 	child, err := d.LookupChild(path.MustNewComponent("file"))
@@ -93,8 +93,8 @@ func TestInMemoryPrepopulatedDirectoryLookupChildDirectory(t *testing.T) {
 	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock)
 
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
-	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("subdir"): virtual.InitialNode{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
+	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("subdir"): virtual.InitialChild{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
 	}, false))
 
 	child, err := d.LookupChild(path.MustNewComponent("subdir"))
@@ -117,8 +117,8 @@ func TestInMemoryPrepopulatedDirectoryLookupAllChildrenFailure(t *testing.T) {
 
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	initialContentsFetcher := mock.NewMockInitialContentsFetcher(ctrl)
-	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("subdir"): virtual.InitialNode{}.FromDirectory(initialContentsFetcher),
+	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("subdir"): virtual.InitialChild{}.FromDirectory(initialContentsFetcher),
 	}, false))
 
 	child, err := d.LookupChild(path.MustNewComponent("subdir"))
@@ -150,9 +150,9 @@ func TestInMemoryPrepopulatedDirectoryLookupAllChildrenSuccess(t *testing.T) {
 	// Populate the directory with files and directories.
 	leaf1 := mock.NewMockLinkableLeaf(ctrl)
 	leaf2 := mock.NewMockLinkableLeaf(ctrl)
-	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("leaf1"):   virtual.InitialNode{}.FromLeaf(leaf1),
-		path.MustNewComponent("._leaf2"): virtual.InitialNode{}.FromLeaf(leaf2),
+	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("leaf1"):   virtual.InitialChild{}.FromLeaf(leaf1),
+		path.MustNewComponent("._leaf2"): virtual.InitialChild{}.FromLeaf(leaf2),
 	}, false))
 
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
@@ -189,10 +189,10 @@ func TestInMemoryPrepopulatedDirectoryReadDir(t *testing.T) {
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	leaf1 := mock.NewMockLinkableLeaf(ctrl)
 	leaf2 := mock.NewMockLinkableLeaf(ctrl)
-	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("directory"):     virtual.InitialNode{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
-		path.MustNewComponent("file"):          virtual.InitialNode{}.FromLeaf(leaf1),
-		path.MustNewComponent("._hidden_file"): virtual.InitialNode{}.FromLeaf(leaf2),
+	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("directory"):     virtual.InitialChild{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
+		path.MustNewComponent("file"):          virtual.InitialChild{}.FromLeaf(leaf1),
+		path.MustNewComponent("._hidden_file"): virtual.InitialChild{}.FromLeaf(leaf2),
 	}, false))
 
 	// Validate directory listing.
@@ -237,8 +237,8 @@ func TestInMemoryPrepopulatedDirectoryRemoveDirectory(t *testing.T) {
 	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock)
 
 	subdirHandle := inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
-	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("directory"): virtual.InitialNode{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
+	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("directory"): virtual.InitialChild{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
 	}, false))
 
 	// Test that removing a directory through filesystem.Directory
@@ -260,12 +260,12 @@ func TestInMemoryPrepopulatedDirectoryRemoveDirectoryNotEmpty(t *testing.T) {
 
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	initialContentsFetcher := mock.NewMockInitialContentsFetcher(ctrl)
-	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("directory"): virtual.InitialNode{}.FromDirectory(initialContentsFetcher),
+	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("directory"): virtual.InitialChild{}.FromDirectory(initialContentsFetcher),
 	}, false))
 	leaf := mock.NewMockLinkableLeaf(ctrl)
-	initialContentsFetcher.EXPECT().FetchContents(gomock.Any()).Return(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("file"): virtual.InitialNode{}.FromLeaf(leaf),
+	initialContentsFetcher.EXPECT().FetchContents(gomock.Any()).Return(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("file"): virtual.InitialChild{}.FromLeaf(leaf),
 	}, nil)
 
 	require.Equal(t, syscall.ENOTEMPTY, d.Remove(path.MustNewComponent("directory")))
@@ -282,8 +282,8 @@ func TestInMemoryPrepopulatedDirectoryRemoveFile(t *testing.T) {
 	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock)
 
 	leaf := mock.NewMockLinkableLeaf(ctrl)
-	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("file"): virtual.InitialNode{}.FromLeaf(leaf),
+	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("file"): virtual.InitialChild{}.FromLeaf(leaf),
 	}, false))
 
 	leaf.EXPECT().Unlink()
@@ -308,9 +308,9 @@ func TestInMemoryPrepopulatedDirectoryCreateChildrenSuccess(t *testing.T) {
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	subdirectoryFetcher := mock.NewMockInitialContentsFetcher(ctrl)
 	topLevelFile := mock.NewMockLinkableLeaf(ctrl)
-	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("dir"):  virtual.InitialNode{}.FromDirectory(subdirectoryFetcher),
-		path.MustNewComponent("file"): virtual.InitialNode{}.FromLeaf(topLevelFile),
+	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("dir"):  virtual.InitialChild{}.FromDirectory(subdirectoryFetcher),
+		path.MustNewComponent("file"): virtual.InitialChild{}.FromLeaf(topLevelFile),
 	}, false))
 
 	// Validate top-level directory listing.
@@ -334,8 +334,8 @@ func TestInMemoryPrepopulatedDirectoryCreateChildrenSuccess(t *testing.T) {
 	child, err := d.LookupChild(path.MustNewComponent("dir"))
 	require.NoError(t, err)
 	subdirectoryFile := mock.NewMockLinkableLeaf(ctrl)
-	subdirectoryFetcher.EXPECT().FetchContents(gomock.Any()).Return(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("file"): virtual.InitialNode{}.FromLeaf(subdirectoryFile),
+	subdirectoryFetcher.EXPECT().FetchContents(gomock.Any()).Return(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("file"): virtual.InitialChild{}.FromLeaf(subdirectoryFile),
 	}, nil)
 	subdirectoryFile.EXPECT().VirtualGetAttributes(
 		gomock.Any(),
@@ -373,7 +373,7 @@ func TestInMemoryPrepopulatedDirectoryCreateChildrenInRemovedDirectory(t *testin
 	require.NoError(t, d.Remove(path.MustNewComponent("directory")))
 
 	// Merging files into the removed directory should fail.
-	require.Equal(t, syscall.ENOENT, child.CreateChildren(map[path.Component]virtual.InitialNode{}, false))
+	require.Equal(t, syscall.ENOENT, child.CreateChildren(map[path.Component]virtual.InitialChild{}, false))
 }
 
 func TestInMemoryPrepopulatedDirectoryInstallHooks(t *testing.T) {
@@ -436,7 +436,7 @@ func TestInMemoryPrepopulatedDirectoryFilterChildren(t *testing.T) {
 	// In the initial state, InMemoryPrepopulatedDirectory will have
 	// an EmptyInitialContentsFetcher associated with it.
 	childFilter1 := mock.NewMockChildFilter(ctrl)
-	childFilter1.EXPECT().Call(virtual.InitialNode{}.FromDirectory(virtual.EmptyInitialContentsFetcher), gomock.Any()).Return(true)
+	childFilter1.EXPECT().Call(virtual.InitialChild{}.FromDirectory(virtual.EmptyInitialContentsFetcher), gomock.Any()).Return(true)
 	require.NoError(t, d.FilterChildren(childFilter1.Call))
 
 	// After attempting to access the directory's contents, the
@@ -457,35 +457,35 @@ func TestInMemoryPrepopulatedDirectoryFilterChildren(t *testing.T) {
 	directory2 := mock.NewMockInitialContentsFetcher(ctrl)
 	leaf1 := mock.NewMockLinkableLeaf(ctrl)
 	leaf2 := mock.NewMockLinkableLeaf(ctrl)
-	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("directory1"): virtual.InitialNode{}.FromDirectory(directory1),
-		path.MustNewComponent("directory2"): virtual.InitialNode{}.FromDirectory(directory2),
-		path.MustNewComponent("leaf1"):      virtual.InitialNode{}.FromLeaf(leaf1),
-		path.MustNewComponent("leaf2"):      virtual.InitialNode{}.FromLeaf(leaf2),
+	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("directory1"): virtual.InitialChild{}.FromDirectory(directory1),
+		path.MustNewComponent("directory2"): virtual.InitialChild{}.FromDirectory(directory2),
+		path.MustNewComponent("leaf1"):      virtual.InitialChild{}.FromLeaf(leaf1),
+		path.MustNewComponent("leaf2"):      virtual.InitialChild{}.FromLeaf(leaf2),
 	}, false))
 
 	childFilter3 := mock.NewMockChildFilter(ctrl)
-	childFilter3.EXPECT().Call(virtual.InitialNode{}.FromDirectory(directory1), gomock.Any()).
-		DoAndReturn(func(initialNode virtual.InitialNode, remove func() error) bool {
+	childFilter3.EXPECT().Call(virtual.InitialChild{}.FromDirectory(directory1), gomock.Any()).
+		DoAndReturn(func(initialChild virtual.InitialChild, remove func() error) bool {
 			require.NoError(t, remove())
 			return true
 		})
-	childFilter3.EXPECT().Call(virtual.InitialNode{}.FromDirectory(directory2), gomock.Any()).Return(true)
-	childFilter3.EXPECT().Call(virtual.InitialNode{}.FromLeaf(leaf1), gomock.Any()).
-		DoAndReturn(func(initialNode virtual.InitialNode, remove func() error) bool {
+	childFilter3.EXPECT().Call(virtual.InitialChild{}.FromDirectory(directory2), gomock.Any()).Return(true)
+	childFilter3.EXPECT().Call(virtual.InitialChild{}.FromLeaf(leaf1), gomock.Any()).
+		DoAndReturn(func(initialChild virtual.InitialChild, remove func() error) bool {
 			leaf1.EXPECT().Unlink()
 			dHandle.EXPECT().NotifyRemoval(path.MustNewComponent("leaf1"))
 			require.NoError(t, remove())
 			return true
 		})
-	childFilter3.EXPECT().Call(virtual.InitialNode{}.FromLeaf(leaf2), gomock.Any()).Return(true)
+	childFilter3.EXPECT().Call(virtual.InitialChild{}.FromLeaf(leaf2), gomock.Any()).Return(true)
 	require.NoError(t, d.FilterChildren(childFilter3.Call))
 
 	// Another call to FilterChildren() should only report the
 	// children that were not removed previously.
 	childFilter4 := mock.NewMockChildFilter(ctrl)
-	childFilter4.EXPECT().Call(virtual.InitialNode{}.FromDirectory(directory2), gomock.Any()).Return(true)
-	childFilter4.EXPECT().Call(virtual.InitialNode{}.FromLeaf(leaf2), gomock.Any()).Return(true)
+	childFilter4.EXPECT().Call(virtual.InitialChild{}.FromDirectory(directory2), gomock.Any()).Return(true)
+	childFilter4.EXPECT().Call(virtual.InitialChild{}.FromLeaf(leaf2), gomock.Any()).Return(true)
 	require.NoError(t, d.FilterChildren(childFilter4.Call))
 }
 
@@ -501,8 +501,8 @@ func TestInMemoryPrepopulatedDirectoryVirtualOpenChildFileExists(t *testing.T) {
 
 	// Create a file at the desired target location.
 	leaf := mock.NewMockLinkableLeaf(ctrl)
-	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("target"): virtual.InitialNode{}.FromLeaf(leaf),
+	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("target"): virtual.InitialChild{}.FromLeaf(leaf),
 	}, false))
 
 	// Trying to create the file through FUSE should fail.
@@ -530,8 +530,8 @@ func TestInMemoryPrepopulatedDirectoryVirtualOpenChildDirectoryExists(t *testing
 
 	// Create a directory at the desired target location.
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
-	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("target"): virtual.InitialNode{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
+	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("target"): virtual.InitialChild{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
 	}, false))
 
 	// Trying to create the file through FUSE should fail.
@@ -704,8 +704,8 @@ func TestInMemoryPrepopulatedDirectoryVirtualLinkExists(t *testing.T) {
 
 	// Attempting to link to a file that already exists should fail.
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
-	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("dir"): virtual.InitialNode{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
+	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("dir"): virtual.InitialChild{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
 	}, false))
 	var attr virtual.Attributes
 	_, s := d.VirtualLink(ctx, path.MustNewComponent("dir"), child, virtual.AttributesMask(0), &attr)
@@ -822,9 +822,9 @@ func TestInMemoryPrepopulatedDirectoryVirtualLookup(t *testing.T) {
 	subdirHandle := inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	file := mock.NewMockLinkableLeaf(ctrl)
 	clock.EXPECT().Now().Return(time.Unix(1001, 0)).Times(3)
-	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("dir"):  virtual.InitialNode{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
-		path.MustNewComponent("file"): virtual.InitialNode{}.FromLeaf(file),
+	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("dir"):  virtual.InitialChild{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
+		path.MustNewComponent("file"): virtual.InitialChild{}.FromLeaf(file),
 	}, false))
 
 	t.Run("NotFound", func(*testing.T) {
@@ -893,8 +893,8 @@ func TestInMemoryPrepopulatedDirectoryVirtualMkdir(t *testing.T) {
 		inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 		initialContentsFetcher := mock.NewMockInitialContentsFetcher(ctrl)
 		clock.EXPECT().Now().Return(time.Unix(1001, 0)).Times(2)
-		require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-			path.MustNewComponent("subdir"): virtual.InitialNode{}.FromDirectory(initialContentsFetcher),
+		require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+			path.MustNewComponent("subdir"): virtual.InitialChild{}.FromDirectory(initialContentsFetcher),
 		}, false))
 
 		child, err := d.LookupChild(path.MustNewComponent("subdir"))
@@ -921,8 +921,8 @@ func TestInMemoryPrepopulatedDirectoryVirtualMkdir(t *testing.T) {
 		// already exists under the provided name.
 		existingFile := mock.NewMockLinkableLeaf(ctrl)
 		clock.EXPECT().Now().Return(time.Unix(1002, 0))
-		require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-			path.MustNewComponent("existing_file"): virtual.InitialNode{}.FromLeaf(existingFile),
+		require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+			path.MustNewComponent("existing_file"): virtual.InitialChild{}.FromLeaf(existingFile),
 		}, false))
 
 		_, _, s := d.VirtualMkdir(path.MustNewComponent("existing_file"), 0, &virtual.Attributes{})
@@ -971,8 +971,8 @@ func TestInMemoryPrepopulatedDirectoryVirtualMknodExists(t *testing.T) {
 
 	// Files may not be overwritten by mknod().
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
-	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("dir"): virtual.InitialNode{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
+	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("dir"): virtual.InitialChild{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
 	}, false))
 	var attr virtual.Attributes
 	_, _, s := d.VirtualMknod(ctx, path.MustNewComponent("dir"), filesystem.FileTypeFIFO, virtual.AttributesMask(0), &attr)
@@ -1069,10 +1069,10 @@ func TestInMemoryPrepopulatedDirectoryVirtualReadDir(t *testing.T) {
 	childFile1 := mock.NewMockLinkableLeaf(ctrl)
 	childFile2 := mock.NewMockLinkableLeaf(ctrl)
 	clock.EXPECT().Now().Return(time.Unix(1001, 0)).Times(4)
-	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("directory"):     virtual.InitialNode{}.FromDirectory(childDirectory),
-		path.MustNewComponent("file"):          virtual.InitialNode{}.FromLeaf(childFile1),
-		path.MustNewComponent("._hidden_file"): virtual.InitialNode{}.FromLeaf(childFile2),
+	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("directory"):     virtual.InitialChild{}.FromDirectory(childDirectory),
+		path.MustNewComponent("file"):          virtual.InitialChild{}.FromLeaf(childFile1),
+		path.MustNewComponent("._hidden_file"): virtual.InitialChild{}.FromLeaf(childFile2),
 	}, false))
 
 	// Obtaining the directory listing through VirtualReadDir() should
@@ -1134,8 +1134,8 @@ func TestInMemoryPrepopulatedDirectoryVirtualRenameSelfDirectory(t *testing.T) {
 	child, err := d.CreateAndEnterPrepopulatedDirectory(path.MustNewComponent("dir"))
 	require.NoError(t, err)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
-	require.NoError(t, child.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("subdir"): virtual.InitialNode{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
+	require.NoError(t, child.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("subdir"): virtual.InitialChild{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
 	}, false))
 	changeInfo1, changeInfo2, s := d.VirtualRename(path.MustNewComponent("dir"), d, path.MustNewComponent("dir"))
 	require.Equal(t, virtual.StatusOK, s)
@@ -1167,8 +1167,8 @@ func TestInMemoryPrepopulatedDirectoryVirtualRenameSelfFile(t *testing.T) {
 	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock)
 
 	leaf := mock.NewMockLinkableLeaf(ctrl)
-	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("a"): virtual.InitialNode{}.FromLeaf(leaf),
+	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("a"): virtual.InitialChild{}.FromLeaf(leaf),
 	}, false))
 
 	leaf.EXPECT().VirtualGetAttributes(
@@ -1239,8 +1239,8 @@ func TestInMemoryPrepopulatedDirectoryVirtualRenameDirectoryInRemovedDirectory(t
 
 	// Moving a directory into it should fail with ENOENT.
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
-	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("dir"): virtual.InitialNode{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
+	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("dir"): virtual.InitialChild{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
 	}, false))
 	_, _, s := d.VirtualRename(path.MustNewComponent("dir"), child, path.MustNewComponent("dir"))
 	require.Equal(t, virtual.StatusErrNoEnt, s)
@@ -1273,8 +1273,8 @@ func TestInMemoryPrepopulatedDirectoryVirtualRenameFileInRemovedDirectory(t *tes
 
 	// Moving a file into it should fail with ENOENT.
 	leaf := mock.NewMockLinkableLeaf(ctrl)
-	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("file"): virtual.InitialNode{}.FromLeaf(leaf),
+	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("file"): virtual.InitialChild{}.FromLeaf(leaf),
 	}, false))
 	_, _, s := d.VirtualRename(path.MustNewComponent("file"), child, path.MustNewComponent("file"))
 	require.Equal(t, virtual.StatusErrNoEnt, s)
@@ -1346,11 +1346,11 @@ func TestInMemoryPrepopulatedDirectoryVirtualRenameDirectoryTwice(t *testing.T) 
 	// Directory "a" got moved over "b", meaning that only the
 	// former should still be usable. The latter has been deleted.
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
-	require.NoError(t, childA.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("subdirectory"): virtual.InitialNode{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
+	require.NoError(t, childA.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("subdirectory"): virtual.InitialChild{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
 	}, false))
-	require.Equal(t, syscall.ENOENT, childB.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("subdirectory"): virtual.InitialNode{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
+	require.Equal(t, syscall.ENOENT, childB.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("subdirectory"): virtual.InitialChild{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
 	}, false))
 }
 
@@ -1394,12 +1394,12 @@ func TestInMemoryPrepopulatedDirectoryVirtualRenameCrossDevice2(t *testing.T) {
 	// hierarchy to another, as this completely messes up
 	// InMemoryPrepopulatedDirectory's internal bookkeeping.
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator1)
-	require.NoError(t, d1.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("src"): virtual.InitialNode{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
+	require.NoError(t, d1.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("src"): virtual.InitialChild{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
 	}, false))
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator2)
-	require.NoError(t, d2.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("dst"): virtual.InitialNode{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
+	require.NoError(t, d2.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("dst"): virtual.InitialChild{}.FromDirectory(virtual.EmptyInitialContentsFetcher),
 	}, false))
 	_, _, s := d1.VirtualRename(path.MustNewComponent("src"), d2, path.MustNewComponent("dst"))
 	require.Equal(t, virtual.StatusErrXDev, s)
@@ -1411,8 +1411,8 @@ func TestInMemoryPrepopulatedDirectoryVirtualRenameCrossDevice2(t *testing.T) {
 	// even if we disallowed this explicitly, it would still be
 	// possible to achieve this by hardlinking.
 	leaf := mock.NewMockLinkableLeaf(ctrl)
-	require.NoError(t, d1.CreateChildren(map[path.Component]virtual.InitialNode{
-		path.MustNewComponent("leaf"): virtual.InitialNode{}.FromLeaf(leaf),
+	require.NoError(t, d1.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("leaf"): virtual.InitialChild{}.FromLeaf(leaf),
 	}, false))
 	changeInfo1, changeInfo2, s := d1.VirtualRename(path.MustNewComponent("leaf"), d2, path.MustNewComponent("leaf"))
 	require.Equal(t, virtual.StatusOK, s)
@@ -1447,8 +1447,8 @@ func TestInMemoryPrepopulatedDirectoryVirtualRemove(t *testing.T) {
 		// directory removal should not be performed.
 		inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 		initialContentsFetcher := mock.NewMockInitialContentsFetcher(ctrl)
-		require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-			path.MustNewComponent("no_directory_removal"): virtual.InitialNode{}.FromDirectory(initialContentsFetcher),
+		require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+			path.MustNewComponent("no_directory_removal"): virtual.InitialChild{}.FromDirectory(initialContentsFetcher),
 		}, false))
 
 		_, s := d.VirtualRemove(path.MustNewComponent("no_directory_removal"), false, true)
@@ -1459,8 +1459,8 @@ func TestInMemoryPrepopulatedDirectoryVirtualRemove(t *testing.T) {
 		// Attempting to remove a leaf, even though leaf removal
 		// should not be performed.
 		leaf := mock.NewMockLinkableLeaf(ctrl)
-		require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-			path.MustNewComponent("no_file_removal"): virtual.InitialNode{}.FromLeaf(leaf),
+		require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+			path.MustNewComponent("no_file_removal"): virtual.InitialChild{}.FromLeaf(leaf),
 		}, false))
 
 		_, s := d.VirtualRemove(path.MustNewComponent("no_file_removal"), true, false)
@@ -1473,8 +1473,8 @@ func TestInMemoryPrepopulatedDirectoryVirtualRemove(t *testing.T) {
 		// removed.
 		inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 		initialContentsFetcher := mock.NewMockInitialContentsFetcher(ctrl)
-		require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-			path.MustNewComponent("broken_directory"): virtual.InitialNode{}.FromDirectory(initialContentsFetcher),
+		require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+			path.MustNewComponent("broken_directory"): virtual.InitialChild{}.FromDirectory(initialContentsFetcher),
 		}, false))
 		initialContentsFetcher.EXPECT().FetchContents(gomock.Any()).
 			Return(nil, status.Error(codes.Internal, "Network error"))
@@ -1487,12 +1487,12 @@ func TestInMemoryPrepopulatedDirectoryVirtualRemove(t *testing.T) {
 	t.Run("ChildDirectoryNotEmpty", func(t *testing.T) {
 		inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 		initialContentsFetcher := mock.NewMockInitialContentsFetcher(ctrl)
-		require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-			path.MustNewComponent("non_empty_directory"): virtual.InitialNode{}.FromDirectory(initialContentsFetcher),
+		require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+			path.MustNewComponent("non_empty_directory"): virtual.InitialChild{}.FromDirectory(initialContentsFetcher),
 		}, false))
 		leaf := mock.NewMockLinkableLeaf(ctrl)
-		initialContentsFetcher.EXPECT().FetchContents(gomock.Any()).Return(map[path.Component]virtual.InitialNode{
-			path.MustNewComponent("file"): virtual.InitialNode{}.FromLeaf(leaf),
+		initialContentsFetcher.EXPECT().FetchContents(gomock.Any()).Return(map[path.Component]virtual.InitialChild{
+			path.MustNewComponent("file"): virtual.InitialChild{}.FromLeaf(leaf),
 		}, nil)
 
 		_, s := d.VirtualRemove(path.MustNewComponent("non_empty_directory"), true, false)
@@ -1501,8 +1501,8 @@ func TestInMemoryPrepopulatedDirectoryVirtualRemove(t *testing.T) {
 
 	t.Run("SuccessFile", func(t *testing.T) {
 		leaf := mock.NewMockLinkableLeaf(ctrl)
-		require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-			path.MustNewComponent("success"): virtual.InitialNode{}.FromLeaf(leaf),
+		require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+			path.MustNewComponent("success"): virtual.InitialChild{}.FromLeaf(leaf),
 		}, false))
 		leaf.EXPECT().Unlink()
 
@@ -1520,14 +1520,14 @@ func TestInMemoryPrepopulatedDirectoryVirtualRemove(t *testing.T) {
 		// of hidden files.
 		dHandle := inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 		initialContentsFetcher := mock.NewMockInitialContentsFetcher(ctrl)
-		require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-			path.MustNewComponent("directory_with_hidden_files"): virtual.InitialNode{}.FromDirectory(initialContentsFetcher),
+		require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+			path.MustNewComponent("directory_with_hidden_files"): virtual.InitialChild{}.FromDirectory(initialContentsFetcher),
 		}, false))
 		leaf1 := mock.NewMockLinkableLeaf(ctrl)
 		leaf2 := mock.NewMockLinkableLeaf(ctrl)
-		initialContentsFetcher.EXPECT().FetchContents(gomock.Any()).Return(map[path.Component]virtual.InitialNode{
-			path.MustNewComponent("._hidden_file1"): virtual.InitialNode{}.FromLeaf(leaf1),
-			path.MustNewComponent("._hidden_file2"): virtual.InitialNode{}.FromLeaf(leaf2),
+		initialContentsFetcher.EXPECT().FetchContents(gomock.Any()).Return(map[path.Component]virtual.InitialChild{
+			path.MustNewComponent("._hidden_file1"): virtual.InitialChild{}.FromLeaf(leaf1),
+			path.MustNewComponent("._hidden_file2"): virtual.InitialChild{}.FromLeaf(leaf2),
 		}, nil)
 		leaf1.EXPECT().Unlink()
 		leaf2.EXPECT().Unlink()
@@ -1556,8 +1556,8 @@ func TestInMemoryPrepopulatedDirectoryVirtualSymlink(t *testing.T) {
 		// Create a subdirectory that has an initial contents fetcher.
 		inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 		initialContentsFetcher := mock.NewMockInitialContentsFetcher(ctrl)
-		require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-			path.MustNewComponent("subdir"): virtual.InitialNode{}.FromDirectory(initialContentsFetcher),
+		require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+			path.MustNewComponent("subdir"): virtual.InitialChild{}.FromDirectory(initialContentsFetcher),
 		}, false))
 
 		child, err := d.LookupChild(path.MustNewComponent("subdir"))
@@ -1583,8 +1583,8 @@ func TestInMemoryPrepopulatedDirectoryVirtualSymlink(t *testing.T) {
 		// The operation should fail if a file or directory
 		// already exists under the provided name.
 		existingFile := mock.NewMockLinkableLeaf(ctrl)
-		require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialNode{
-			path.MustNewComponent("existing_file"): virtual.InitialNode{}.FromLeaf(existingFile),
+		require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+			path.MustNewComponent("existing_file"): virtual.InitialChild{}.FromLeaf(existingFile),
 		}, false))
 
 		_, _, s := d.VirtualSymlink(ctx, []byte("target"), path.MustNewComponent("existing_file"), 0, &virtual.Attributes{})

--- a/pkg/filesystem/virtual/initial_contents_fetcher.go
+++ b/pkg/filesystem/virtual/initial_contents_fetcher.go
@@ -1,16 +1,22 @@
 package virtual
 
 import (
-	"context"
-
-	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/filesystem/path"
 )
+
+// InitialNode contains the common set of operations that can be applied
+// against files and directories returned by
+// InitialContentsFetcher.FetchContents().
+type InitialNode interface {
+	// VirtualApply can be used to perform implementation defined
+	// operations against files and directories.
+	VirtualApply(data any) bool
+}
 
 // InitialChild is the value type of the map of directory entries
 // returned by InitialContentsFetcher.FetchContents(). Either Directory
 // or Leaf is set, but not both.
-type InitialChild = Child[InitialContentsFetcher, LinkableLeaf, any]
+type InitialChild = Child[InitialContentsFetcher, LinkableLeaf, InitialNode]
 
 // FileReadMonitor is used by the regular files created through the
 // InitialContentsFetcher to indicate that one or more calls against
@@ -35,21 +41,7 @@ type FileReadMonitorFactory func(name path.Component) FileReadMonitor
 // may be possible FetchContents() is never called. This may happen if
 // the directory in question is never accessed.
 type InitialContentsFetcher interface {
-	FetchContents(fileReadMonitorFactory FileReadMonitorFactory) (map[path.Component]InitialChild, error)
+	InitialNode
 
-	// GetContainingDigests() returns a set of digests of objects in
-	// the Content Addressable Storage that back the directories and
-	// leaf nodes yielded by this InitialContentsFetcher.
-	//
-	// The set returned by this function may be passed to
-	// ContentAddressableStorage.FindMissingBlobs() to check whether
-	// the all files underneath this directory still exist, and to
-	// prevent them from being removed in the nearby future.
-	//
-	// This API assumes that the resulting set is small enough to
-	// fit in memory. For hierarchies backed by Tree objects, this
-	// will generally hold. It may not be safe to call this method
-	// on InitialContentsFetchers that expand to infinitely big
-	// hierarchies.
-	GetContainingDigests(ctx context.Context) (digest.Set, error)
+	FetchContents(fileReadMonitorFactory FileReadMonitorFactory) (map[path.Component]InitialChild, error)
 }

--- a/pkg/filesystem/virtual/initial_contents_fetcher.go
+++ b/pkg/filesystem/virtual/initial_contents_fetcher.go
@@ -7,10 +7,10 @@ import (
 	"github.com/buildbarn/bb-storage/pkg/filesystem/path"
 )
 
-// InitialNode is the value type of the map of directory entries
+// InitialChild is the value type of the map of directory entries
 // returned by InitialContentsFetcher.FetchContents(). Either Directory
 // or Leaf is set, but not both.
-type InitialNode = Child[InitialContentsFetcher, LinkableLeaf, any]
+type InitialChild = Child[InitialContentsFetcher, LinkableLeaf, any]
 
 // FileReadMonitor is used by the regular files created through the
 // InitialContentsFetcher to indicate that one or more calls against
@@ -35,7 +35,7 @@ type FileReadMonitorFactory func(name path.Component) FileReadMonitor
 // may be possible FetchContents() is never called. This may happen if
 // the directory in question is never accessed.
 type InitialContentsFetcher interface {
-	FetchContents(fileReadMonitorFactory FileReadMonitorFactory) (map[path.Component]InitialNode, error)
+	FetchContents(fileReadMonitorFactory FileReadMonitorFactory) (map[path.Component]InitialChild, error)
 
 	// GetContainingDigests() returns a set of digests of objects in
 	// the Content Addressable Storage that back the directories and

--- a/pkg/filesystem/virtual/linkable_leaf.go
+++ b/pkg/filesystem/virtual/linkable_leaf.go
@@ -4,6 +4,7 @@ package virtual
 // PrepopulatedDirectory.
 type LinkableLeaf interface {
 	Leaf
+	InitialNode
 
 	// Operations called into by implementations of
 	// PrepopulatedDirectory. The Link() operation may fail, for the

--- a/pkg/filesystem/virtual/node.go
+++ b/pkg/filesystem/virtual/node.go
@@ -68,8 +68,12 @@ type ApplyUploadFile struct {
 // the file still exists in its entirety, and to prevent that
 // the file is removed in the nearby future.
 type ApplyGetContainingDigests struct {
+	// Inputs.
+	Context context.Context
+
 	// Outputs.
 	ContainingDigests digest.Set
+	Err               error
 }
 
 // ApplyGetBazelOutputServiceStat is an operation for VirtualApply that

--- a/pkg/filesystem/virtual/placeholder_file.go
+++ b/pkg/filesystem/virtual/placeholder_file.go
@@ -3,7 +3,6 @@ package virtual
 import (
 	"context"
 
-	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/filesystem"
 
 	"google.golang.org/grpc/codes"
@@ -52,8 +51,6 @@ func (placeholderFile) VirtualApply(data any) bool {
 	switch p := data.(type) {
 	case *ApplyUploadFile:
 		p.Err = status.Error(codes.InvalidArgument, "This file cannot be uploaded, as it is a placeholder")
-	case *ApplyGetContainingDigests:
-		p.ContainingDigests = digest.EmptySet
 	default:
 		return false
 	}

--- a/pkg/filesystem/virtual/pool_backed_file_allocator.go
+++ b/pkg/filesystem/virtual/pool_backed_file_allocator.go
@@ -351,8 +351,6 @@ func (f *fileBackedFile) VirtualApply(data any) bool {
 		p.Err = syscall.EINVAL
 	case *ApplyUploadFile:
 		p.Digest, p.Err = f.uploadFile(p.Context, p.ContentAddressableStorage, p.DigestFunction, p.WritableFileUploadDelay)
-	case *ApplyGetContainingDigests:
-		p.ContainingDigests = digest.EmptySet
 	case *ApplyGetBazelOutputServiceStat:
 		p.Stat, p.Err = f.getBazelOutputServiceStat(p.DigestFunction)
 	case *ApplyAppendOutputPathPersistencyDirectoryNode:

--- a/pkg/filesystem/virtual/prepopulated_directory.go
+++ b/pkg/filesystem/virtual/prepopulated_directory.go
@@ -14,7 +14,7 @@ type ChildRemover func() error
 // PrepopulatedDirectory.FilterChildren() for each of the children
 // underneath the current directory hierarchy.
 //
-// For each of the children, an InitialNode object is provided that
+// For each of the children, an InitialChild object is provided that
 // describes the contents of that file or directory. In addition to
 // that, a callback is provided that can remove the file or the contents
 // of the directory. This callback may be invoked synchronously or
@@ -22,7 +22,7 @@ type ChildRemover func() error
 //
 // The boolean return value of this function signals whether traversal
 // should continue. When false, traversal will stop immediately.
-type ChildFilter func(node InitialNode, remove ChildRemover) bool
+type ChildFilter func(node InitialChild, remove ChildRemover) bool
 
 // DirectoryPrepopulatedDirEntry contains information about a directory
 // node that is stored in a PrepopulatedDirectory.
@@ -75,7 +75,7 @@ type PrepopulatedDirectory interface {
 	// will be replaced. If the overwrite flag is not set, the call
 	// will fail if one or more entries already exist. No changes
 	// will be made to the directory in that case.
-	CreateChildren(children map[path.Component]InitialNode, overwrite bool) error
+	CreateChildren(children map[path.Component]InitialChild, overwrite bool) error
 	// CreateAndEnterPrepopulatedDirectory() is similar to
 	// LookupChild(), except that it creates the specified directory
 	// if it does not yet exist. If a file already exists, it will


### PR DESCRIPTION
Right now we have completely different code paths for computing the    containing digests for files and directories. For files we call    LinkableLeaf.VirtualApply(), while for directories we call    InitialContentsFetcher.GetContainingDigests().
    
The downside of the current approach is that generic virtual file system    APIs are strongly coupled against REv2. By giving InitialContentsFetcher    a VirtualApply(), we get rid of the coupling. In addition to that, it's    now possible to call InitialChild.GetNode().VirtualApply() to obtain the    set of containing digests in a file type oblivious way.