### PR TITLE
Log failure to close and remove build directory

### DIFF
--- a/pkg/builder/local_build_executor.go
+++ b/pkg/builder/local_build_executor.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"context"
+	"log"
 	"os"
 	"sync"
 	"time"
@@ -114,7 +115,11 @@ func (be *localBuildExecutor) CheckReadiness(ctx context.Context) error {
 	if err != nil {
 		return util.StatusWrap(err, "Failed to get build directory")
 	}
-	defer buildDirectory.Close()
+	defer func() {
+		if err := buildDirectory.Close(); err != nil {
+			log.Printf("Failed to close build directory %s: %s", buildDirectoryPath.GetUNIXString(), err)
+		}
+	}()
 
 	// Create a useless directory inside the build directory. The
 	// runner will validate that it exists.
@@ -166,6 +171,7 @@ func (be *localBuildExecutor) Execute(ctx context.Context, filePool re_filesyste
 			attachErrorToExecuteResponse(
 				response,
 				util.StatusWrap(err, "Failed to close build directory"))
+			log.Printf("Failed to close build directory %s: %s", buildDirectoryPath.GetUNIXString(), err)
 		}
 	}()
 


### PR DESCRIPTION
There is no real way to forward directory deletion errors when an execution has finished and a response has been sent. Therefore, print it as a log.