### PR TITLE
Fix tools/BUILD.bazel to make 'bazel cquery ...' work

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,15 +1,1 @@
-load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template")
-load("@rules_go//go:def.bzl", "go_library")
-
-go_library(
-    name = "tools",
-    srcs = ["deps.go"],
-    importpath = "github.com/buildbarn/bb-remote-execution/tools",
-    tags = ["manual"],
-    visibility = ["//visibility:public"],
-    deps = [
-        "@cc_mvdan_gofumpt//:gofumpt",
-        "@com_github_bazelbuild_buildtools//buildifier",
-        "@org_golang_x_lint//:lint",
-    ],
-)
+# gazelle:ignore


### PR DESCRIPTION
ibazel (https://github.com/bazelbuild/bazel-watcher/) is running `bazel cquery ...` which failed when there are executable targets in the deps attribute of a go_library. This was never checked in CI because of the manual tag of the tools target.