### PR TITLE
chore: order proto by field number

### DIFF
--- a/pkg/proto/configuration/bb_scheduler/bb_scheduler.proto
+++ b/pkg/proto/configuration/bb_scheduler/bb_scheduler.proto
@@ -18,18 +18,6 @@ message ApplicationConfiguration {
   // server can now be configured through 'admin_http_servers'.
   reserved 2;
 
-  // Configuration for the HTTP servers that expose the web UI.
-  //
-  // TODO: This web UI no longer needs to be integrated into
-  // bb_scheduler, as the underlying information can be exposed over
-  // gRPC using the 'build_queue_state_grpc_servers' option.
-  repeated buildbarn.configuration.http.ServerConfiguration admin_http_servers =
-      19;
-
-  // The path under which the administrative web UI needs to be exposed.
-  // When left empty, the web UI will be exposed at "/".
-  string admin_route_prefix = 22;
-
   // gRPC servers to spawn to listen for requests from clients
   // (bb_storage or Bazel).
   repeated buildbarn.configuration.grpc.ServerConfiguration
@@ -83,26 +71,6 @@ message ApplicationConfiguration {
   // requests.
   buildbarn.configuration.auth.AuthorizerConfiguration execute_authorizer = 15;
 
-  // Authorization requirements to be enforced for AddDrain and
-  // RemoveDrain requests issued through the BuildQueueState gRPC
-  // servers and web UI.
-  //
-  // The instance name to be matched is the instance name prefix of the
-  // size class queue to which drains are added, or from which drains
-  // are removed.
-  buildbarn.configuration.auth.AuthorizerConfiguration
-      modify_drains_authorizer = 20;
-
-  // Authorization requirements to be enforced for KillOperations
-  // RemoveDrain requests issued through the BuildQueueState gRPC
-  // servers and web UI.
-  //
-  // The instance name to be matched is the instance name prefix of the
-  // size class queue containing the operation. Not the instance name
-  // used by the operation itself.
-  buildbarn.configuration.auth.AuthorizerConfiguration
-      kill_operations_authorizer = 21;
-
   // The policy for routing actions.
   //
   // Before the scheduler is capable of enqueueing an action, it must
@@ -153,6 +121,38 @@ message ApplicationConfiguration {
   //
   // Recommended value: 900s
   google.protobuf.Duration platform_queue_with_no_workers_timeout = 18;
+
+  // Configuration for the HTTP servers that expose the web UI.
+  //
+  // TODO: This web UI no longer needs to be integrated into
+  // bb_scheduler, as the underlying information can be exposed over
+  // gRPC using the 'build_queue_state_grpc_servers' option.
+  repeated buildbarn.configuration.http.ServerConfiguration admin_http_servers =
+      19;
+
+  // Authorization requirements to be enforced for AddDrain and
+  // RemoveDrain requests issued through the BuildQueueState gRPC
+  // servers and web UI.
+  //
+  // The instance name to be matched is the instance name prefix of the
+  // size class queue to which drains are added, or from which drains
+  // are removed.
+  buildbarn.configuration.auth.AuthorizerConfiguration
+      modify_drains_authorizer = 20;
+
+  // Authorization requirements to be enforced for KillOperations
+  // RemoveDrain requests issued through the BuildQueueState gRPC
+  // servers and web UI.
+  //
+  // The instance name to be matched is the instance name prefix of the
+  // size class queue containing the operation. Not the instance name
+  // used by the operation itself.
+  buildbarn.configuration.auth.AuthorizerConfiguration
+      kill_operations_authorizer = 21;
+
+  // The path under which the administrative web UI needs to be exposed.
+  // When left empty, the web UI will be exposed at "/".
+  string admin_route_prefix = 22;
 }
 
 message PredeclaredPlatformQueueConfiguration {

--- a/pkg/proto/configuration/bb_worker/bb_worker.proto
+++ b/pkg/proto/configuration/bb_worker/bb_worker.proto
@@ -69,17 +69,6 @@ message ApplicationConfiguration {
   // for more details around the Completed Action Logger service.
   repeated CompletedActionLoggingConfiguration completed_action_loggers = 23;
 
-  // When native build directories are used, the maximum number of
-  // concurrent files to instantiate in input roots.
-  //
-  // When virtual build directories (FUSE/NFSv4) are used, the maximum
-  // number of concurrent files to read from the Content Addressable
-  // Storage (CAS) while prefetching.
-  //
-  // This limit applied to the worker process as a whole; not individual
-  // worker threads.
-  int64 input_download_concurrency = 28;
-
   // The maximum number of concurrent writes to issue against the
   // Content Addressable Storage (CAS). This limit applies to the worker
   // process as a whole; not individual worker threads.
@@ -155,6 +144,17 @@ message ApplicationConfiguration {
   // The disadvantage of enabling this option is that a larger number of
   // objects are written into the CAS.
   bool force_upload_trees_and_directories = 27;
+
+  // When native build directories are used, the maximum number of
+  // concurrent files to instantiate in input roots.
+  //
+  // When virtual build directories (FUSE/NFSv4) are used, the maximum
+  // number of concurrent files to read from the Content Addressable
+  // Storage (CAS) while prefetching.
+  //
+  // This limit applied to the worker process as a whole; not individual
+  // worker threads.
+  int64 input_download_concurrency = 28;
 }
 
 message BuildDirectoryConfiguration {


### PR DESCRIPTION
When adding new fields to `.proto` files, it can be hard to figure out which field to start with.

This PR is a simple formatting change to keep this proto file sorted.