### PR TITLE
Disable support for REv2.0 output_{files,directories} by default

### DIFF
--- a/cmd/bb_worker/main.go
+++ b/cmd/bb_worker/main.go
@@ -410,7 +410,9 @@ func main() {
 						inputRootCharacterDevices,
 						int(configuration.MaximumMessageSizeBytes),
 						runnerConfiguration.EnvironmentVariables,
-						configuration.ForceUploadTreesAndDirectories)
+						configuration.ForceUploadTreesAndDirectories,
+						configuration.SupportLegacyOutputFilesAndDirectories,
+					)
 
 					if prefetchingConfiguration != nil {
 						buildExecutor = builder.NewPrefetchingBuildExecutor(

--- a/pkg/builder/command.go
+++ b/pkg/builder/command.go
@@ -86,7 +86,7 @@ func ConvertCommandToShellScript(command *remoteexecution.Command, w io.StringWr
 	}
 
 	// Create parent directories of outputs.
-	outputHierarchy, err := NewOutputHierarchy(command)
+	outputHierarchy, err := NewOutputHierarchy(command, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/builder/local_build_executor.go
+++ b/pkg/builder/local_build_executor.go
@@ -65,30 +65,32 @@ func (el *capturingErrorLogger) GetError() error {
 }
 
 type localBuildExecutor struct {
-	contentAddressableStorage      blobstore.BlobAccess
-	buildDirectoryCreator          BuildDirectoryCreator
-	runner                         runner_pb.RunnerClient
-	clock                          clock.Clock
-	maximumWritableFileUploadDelay time.Duration
-	inputRootCharacterDevices      map[path.Component]filesystem.DeviceNumber
-	maximumMessageSizeBytes        int
-	environmentVariables           map[string]string
-	forceUploadTreesAndDirectories bool
+	contentAddressableStorage              blobstore.BlobAccess
+	buildDirectoryCreator                  BuildDirectoryCreator
+	runner                                 runner_pb.RunnerClient
+	clock                                  clock.Clock
+	maximumWritableFileUploadDelay         time.Duration
+	inputRootCharacterDevices              map[path.Component]filesystem.DeviceNumber
+	maximumMessageSizeBytes                int
+	environmentVariables                   map[string]string
+	forceUploadTreesAndDirectories         bool
+	supportLegacyOutputFilesAndDirectories bool
 }
 
 // NewLocalBuildExecutor returns a BuildExecutor that executes build
 // steps on the local system.
-func NewLocalBuildExecutor(contentAddressableStorage blobstore.BlobAccess, buildDirectoryCreator BuildDirectoryCreator, runner runner_pb.RunnerClient, clock clock.Clock, maximumWritableFileUploadDelay time.Duration, inputRootCharacterDevices map[path.Component]filesystem.DeviceNumber, maximumMessageSizeBytes int, environmentVariables map[string]string, forceUploadTreesAndDirectories bool) BuildExecutor {
+func NewLocalBuildExecutor(contentAddressableStorage blobstore.BlobAccess, buildDirectoryCreator BuildDirectoryCreator, runner runner_pb.RunnerClient, clock clock.Clock, maximumWritableFileUploadDelay time.Duration, inputRootCharacterDevices map[path.Component]filesystem.DeviceNumber, maximumMessageSizeBytes int, environmentVariables map[string]string, forceUploadTreesAndDirectories, supportLegacyOutputFilesAndDirectories bool) BuildExecutor {
 	return &localBuildExecutor{
-		contentAddressableStorage:      contentAddressableStorage,
-		buildDirectoryCreator:          buildDirectoryCreator,
-		runner:                         runner,
-		clock:                          clock,
-		maximumWritableFileUploadDelay: maximumWritableFileUploadDelay,
-		inputRootCharacterDevices:      inputRootCharacterDevices,
-		maximumMessageSizeBytes:        maximumMessageSizeBytes,
-		environmentVariables:           environmentVariables,
-		forceUploadTreesAndDirectories: forceUploadTreesAndDirectories,
+		contentAddressableStorage:              contentAddressableStorage,
+		buildDirectoryCreator:                  buildDirectoryCreator,
+		runner:                                 runner,
+		clock:                                  clock,
+		maximumWritableFileUploadDelay:         maximumWritableFileUploadDelay,
+		inputRootCharacterDevices:              inputRootCharacterDevices,
+		maximumMessageSizeBytes:                maximumMessageSizeBytes,
+		environmentVariables:                   environmentVariables,
+		forceUploadTreesAndDirectories:         forceUploadTreesAndDirectories,
+		supportLegacyOutputFilesAndDirectories: supportLegacyOutputFilesAndDirectories,
 	}
 }
 
@@ -231,7 +233,7 @@ func (be *localBuildExecutor) Execute(ctx context.Context, filePool pool.FilePoo
 		return response
 	}
 	command := commandMessage.(*remoteexecution.Command)
-	outputHierarchy, err := NewOutputHierarchy(command)
+	outputHierarchy, err := NewOutputHierarchy(command, be.supportLegacyOutputFilesAndDirectories)
 	if err != nil {
 		attachErrorToExecuteResponse(response, err)
 		return response

--- a/pkg/builder/local_build_executor_test.go
+++ b/pkg/builder/local_build_executor_test.go
@@ -47,7 +47,9 @@ func TestLocalBuildExecutorInvalidActionDigest(t *testing.T) {
 		/* inputRootCharacterDevices = */ nil,
 		/* maximumMessageSizeBytes = */ 10000,
 		/* environmentVariables = */ map[string]string{},
-		/* forceUploadTreesAndDirectories = */ false)
+		/* forceUploadTreesAndDirectories = */ false,
+		/* supportLegacyOutputFilesAndDirectories = */ false,
+	)
 
 	filePool := mock.NewMockFilePool(ctrl)
 	monitor := mock.NewMockUnreadDirectoryMonitor(ctrl)
@@ -95,7 +97,9 @@ func TestLocalBuildExecutorMissingAction(t *testing.T) {
 		/* inputRootCharacterDevices = */ nil,
 		/* maximumMessageSizeBytes = */ 10000,
 		/* environmentVariables = */ map[string]string{},
-		/* forceUploadTreesAndDirectories = */ false)
+		/* forceUploadTreesAndDirectories = */ false,
+		/* supportLegacyOutputFilesAndDirectories = */ false,
+	)
 
 	filePool := mock.NewMockFilePool(ctrl)
 	monitor := mock.NewMockUnreadDirectoryMonitor(ctrl)
@@ -139,7 +143,9 @@ func TestLocalBuildExecutorBuildDirectoryCreatorFailedFailed(t *testing.T) {
 		/* inputRootCharacterDevices = */ nil,
 		/* maximumMessageSizeBytes = */ 10000,
 		/* environmentVariables = */ map[string]string{},
-		/* forceUploadTreesAndDirectories = */ false)
+		/* forceUploadTreesAndDirectories = */ false,
+		/* supportLegacyOutputFilesAndDirectories = */ false,
+	)
 
 	filePool := mock.NewMockFilePool(ctrl)
 	monitor := mock.NewMockUnreadDirectoryMonitor(ctrl)
@@ -205,7 +211,9 @@ func TestLocalBuildExecutorInputRootPopulationFailed(t *testing.T) {
 		/* inputRootCharacterDevices = */ nil,
 		/* maximumMessageSizeBytes = */ 10000,
 		/* environmentVariables = */ map[string]string{},
-		/* forceUploadTreesAndDirectories = */ false)
+		/* forceUploadTreesAndDirectories = */ false,
+		/* supportLegacyOutputFilesAndDirectories = */ false,
+	)
 
 	metadata := make(chan *remoteworker.CurrentState_Executing, 10)
 	executeResponse := localBuildExecutor.Execute(
@@ -280,7 +288,9 @@ func TestLocalBuildExecutorOutputDirectoryCreationFailure(t *testing.T) {
 		/* inputRootCharacterDevices = */ nil,
 		/* maximumMessageSizeBytes = */ 10000,
 		/* environmentVariables = */ map[string]string{},
-		/* forceUploadTreesAndDirectories = */ false)
+		/* forceUploadTreesAndDirectories = */ false,
+		/* supportLegacyOutputFilesAndDirectories = */ false,
+	)
 
 	metadata := make(chan *remoteworker.CurrentState_Executing, 10)
 	executeResponse := localBuildExecutor.Execute(
@@ -348,7 +358,9 @@ func TestLocalBuildExecutorMissingCommand(t *testing.T) {
 		/* inputRootCharacterDevices = */ nil,
 		/* maximumMessageSizeBytes = */ 10000,
 		/* environmentVariables = */ map[string]string{},
-		/* forceUploadTreesAndDirectories = */ false)
+		/* forceUploadTreesAndDirectories = */ false,
+		/* supportLegacyOutputFilesAndDirectories = */ false,
+	)
 
 	metadata := make(chan *remoteworker.CurrentState_Executing, 10)
 	executeResponse := localBuildExecutor.Execute(
@@ -473,7 +485,9 @@ func TestLocalBuildExecutorOutputSymlinkReadingFailure(t *testing.T) {
 		/* inputRootCharacterDevices = */ nil,
 		/* maximumMessageSizeBytes = */ 10000,
 		/* environmentVariables = */ map[string]string{},
-		/* forceUploadTreesAndDirectories = */ false)
+		/* forceUploadTreesAndDirectories = */ false,
+		/* supportLegacyOutputFilesAndDirectories = */ false,
+	)
 
 	metadata := make(chan *remoteworker.CurrentState_Executing, 10)
 	executeResponse := localBuildExecutor.Execute(
@@ -704,7 +718,9 @@ func TestLocalBuildExecutorSuccess(t *testing.T) {
 			"TEST_VAR": "123",
 			"PWD":      "dont-overwrite",
 		},
-		/* forceUploadTreesAndDirectories = */ false)
+		/* forceUploadTreesAndDirectories = */ false,
+		/* supportLegacyOutputFilesAndDirectories = */ false,
+	)
 
 	requestMetadata, err := anypb.New(&remoteexecution.RequestMetadata{
 		ToolInvocationId: "666b72d8-c43e-4998-866c-9312a31fe86d",
@@ -786,7 +802,9 @@ func TestLocalBuildExecutorCachingInvalidTimeout(t *testing.T) {
 		/* inputRootCharacterDevices = */ nil,
 		/* maximumMessageSizeBytes = */ 10000,
 		/* environmentVariables = */ map[string]string{},
-		/* forceUploadTreesAndDirectories = */ false)
+		/* forceUploadTreesAndDirectories = */ false,
+		/* supportLegacyOutputFilesAndDirectories = */ false,
+	)
 
 	// Execution should fail, as the number of nanoseconds in the
 	// timeout is not within bounds.
@@ -904,7 +922,9 @@ func TestLocalBuildExecutorInputRootIOFailureDuringExecution(t *testing.T) {
 		/* inputRootCharacterDevices = */ nil,
 		/* maximumMessageSizeBytes = */ 10000,
 		/* environmentVariables = */ map[string]string{},
-		/* forceUploadTreesAndDirectories = */ false)
+		/* forceUploadTreesAndDirectories = */ false,
+		/* supportLegacyOutputFilesAndDirectories = */ false,
+	)
 
 	metadata := make(chan *remoteworker.CurrentState_Executing, 10)
 	executeResponse := localBuildExecutor.Execute(
@@ -1035,7 +1055,9 @@ func TestLocalBuildExecutorTimeoutDuringExecution(t *testing.T) {
 		/* inputRootCharacterDevices = */ nil,
 		/* maximumMessageSizeBytes = */ 10000,
 		/* environmentVariables = */ map[string]string{},
-		/* forceUploadTreesAndDirectories = */ false)
+		/* forceUploadTreesAndDirectories = */ false,
+		/* supportLegacyOutputFilesAndDirectories = */ false,
+	)
 
 	metadata := make(chan *remoteworker.CurrentState_Executing, 10)
 	executeResponse := localBuildExecutor.Execute(
@@ -1135,7 +1157,9 @@ func TestLocalBuildExecutorCharacterDeviceNodeCreationFailed(t *testing.T) {
 		},
 		/* maximumMessageSizeBytes = */ 10000,
 		/* environmentVariables = */ map[string]string{},
-		/* forceUploadTreesAndDirectories = */ false)
+		/* forceUploadTreesAndDirectories = */ false,
+		/* supportLegacyOutputFilesAndDirectories = */ false,
+	)
 
 	metadata := make(chan *remoteworker.CurrentState_Executing, 10)
 	executeResponse := localBuildExecutor.Execute(

--- a/pkg/builder/output_hierarchy_test.go
+++ b/pkg/builder/output_hierarchy_test.go
@@ -26,14 +26,14 @@ func TestOutputHierarchyCreation(t *testing.T) {
 	t.Run("AbsoluteWorkingDirectory", func(t *testing.T) {
 		_, err := builder.NewOutputHierarchy(&remoteexecution.Command{
 			WorkingDirectory: "/tmp/hello/../..",
-		})
+		}, false)
 		testutil.RequireEqualStatus(t, status.Error(codes.InvalidArgument, "Invalid working directory: Path is absolute, while a relative path was expected"), err)
 	})
 
 	t.Run("InvalidWorkingDirectory", func(t *testing.T) {
 		_, err := builder.NewOutputHierarchy(&remoteexecution.Command{
 			WorkingDirectory: "hello/../..",
-		})
+		}, false)
 		testutil.RequireEqualStatus(t, status.Error(codes.InvalidArgument, "Invalid working directory: Path resolves to a location outside the input root directory"), err)
 	})
 
@@ -41,7 +41,7 @@ func TestOutputHierarchyCreation(t *testing.T) {
 		_, err := builder.NewOutputHierarchy(&remoteexecution.Command{
 			WorkingDirectory:  ".",
 			OutputDirectories: []string{"/etc/passwd"},
-		})
+		}, true)
 		testutil.RequireEqualStatus(t, status.Error(codes.InvalidArgument, "Invalid output directory \"/etc/passwd\": Path is absolute, while a relative path was expected"), err)
 	})
 
@@ -49,7 +49,7 @@ func TestOutputHierarchyCreation(t *testing.T) {
 		_, err := builder.NewOutputHierarchy(&remoteexecution.Command{
 			WorkingDirectory:  "hello",
 			OutputDirectories: []string{"../.."},
-		})
+		}, true)
 		testutil.RequireEqualStatus(t, status.Error(codes.InvalidArgument, "Invalid output directory \"../..\": Path resolves to a location outside the input root directory"), err)
 	})
 
@@ -57,7 +57,7 @@ func TestOutputHierarchyCreation(t *testing.T) {
 		_, err := builder.NewOutputHierarchy(&remoteexecution.Command{
 			WorkingDirectory: "hello",
 			OutputFiles:      []string{".."},
-		})
+		}, true)
 		testutil.RequireEqualStatus(t, status.Error(codes.InvalidArgument, "Output file \"..\" resolves to the input root directory"), err)
 	})
 }
@@ -71,7 +71,7 @@ func TestOutputHierarchyCreateParentDirectories(t *testing.T) {
 		// No parent directories should be created.
 		oh, err := builder.NewOutputHierarchy(&remoteexecution.Command{
 			WorkingDirectory: ".",
-		})
+		}, false)
 		require.NoError(t, err)
 		require.NoError(t, oh.CreateParentDirectories(root))
 	})
@@ -83,7 +83,7 @@ func TestOutputHierarchyCreateParentDirectories(t *testing.T) {
 		// not cause any Mkdir() calls.
 		oh, err := builder.NewOutputHierarchy(&remoteexecution.Command{
 			WorkingDirectory: "foo/bar",
-		})
+		}, true)
 		require.NoError(t, err)
 		require.NoError(t, oh.CreateParentDirectories(root))
 	})
@@ -97,7 +97,7 @@ func TestOutputHierarchyCreateParentDirectories(t *testing.T) {
 			OutputDirectories: []string{".."},
 			OutputFiles:       []string{"../file"},
 			OutputPaths:       []string{"../path"},
-		})
+		}, false)
 		require.NoError(t, err)
 		require.NoError(t, oh.CreateParentDirectories(root))
 	})
@@ -120,7 +120,7 @@ func TestOutputHierarchyCreateParentDirectories(t *testing.T) {
 			WorkingDirectory:  "foo",
 			OutputDirectories: []string{"bar/baz"},
 			OutputFiles:       []string{"../foo/qux/xyzzy"},
-		})
+		}, true)
 		require.NoError(t, err)
 		require.NoError(t, oh.CreateParentDirectories(root))
 	})
@@ -135,7 +135,7 @@ func TestOutputHierarchyCreateParentDirectories(t *testing.T) {
 			OutputDirectories: []string{"bar/baz"},
 			OutputFiles:       []string{"../foo/qux/xyzzy"},
 			OutputPaths:       []string{"../alice/bob"},
-		})
+		}, false)
 		require.NoError(t, err)
 		require.NoError(t, oh.CreateParentDirectories(root))
 	})
@@ -152,7 +152,7 @@ func TestOutputHierarchyCreateParentDirectories(t *testing.T) {
 		oh, err := builder.NewOutputHierarchy(&remoteexecution.Command{
 			WorkingDirectory: "foo",
 			OutputFiles:      []string{"bar/baz"},
-		})
+		}, true)
 		require.NoError(t, err)
 		testutil.RequireEqualStatus(
 			t,
@@ -173,7 +173,7 @@ func TestOutputHierarchyCreateParentDirectories(t *testing.T) {
 		oh, err := builder.NewOutputHierarchy(&remoteexecution.Command{
 			WorkingDirectory: "foo",
 			OutputFiles:      []string{"bar/baz"},
-		})
+		}, true)
 		require.NoError(t, err)
 		require.NoError(t, oh.CreateParentDirectories(root))
 	})
@@ -190,7 +190,7 @@ func TestOutputHierarchyCreateParentDirectories(t *testing.T) {
 		oh, err := builder.NewOutputHierarchy(&remoteexecution.Command{
 			WorkingDirectory:  "foo",
 			OutputDirectories: []string{"bar"},
-		})
+		}, true)
 		require.NoError(t, err)
 		testutil.RequireEqualStatus(
 			t,
@@ -211,7 +211,7 @@ func TestOutputHierarchyCreateParentDirectories(t *testing.T) {
 		oh, err := builder.NewOutputHierarchy(&remoteexecution.Command{
 			WorkingDirectory:  "foo",
 			OutputDirectories: []string{"bar"},
-		})
+		}, true)
 		require.NoError(t, err)
 		require.NoError(t, oh.CreateParentDirectories(root))
 	})
@@ -227,7 +227,7 @@ func TestOutputHierarchyCreateParentDirectories(t *testing.T) {
 		oh, err := builder.NewOutputHierarchy(&remoteexecution.Command{
 			WorkingDirectory:  "foo",
 			OutputDirectories: []string{"bar/baz"},
-		})
+		}, true)
 		require.NoError(t, err)
 		testutil.RequireEqualStatus(
 			t,
@@ -249,7 +249,7 @@ func TestOutputHierarchyUploadOutputs(t *testing.T) {
 		// should not trigger any I/O.
 		oh, err := builder.NewOutputHierarchy(&remoteexecution.Command{
 			WorkingDirectory: ".",
-		})
+		}, false)
 		require.NoError(t, err)
 		var actionResult remoteexecution.ActionResult
 		require.NoError(
@@ -391,7 +391,7 @@ func TestOutputHierarchyUploadOutputs(t *testing.T) {
 
 		foo.EXPECT().Close()
 
-		oh, err := builder.NewOutputHierarchy(command)
+		oh, err := builder.NewOutputHierarchy(command, true)
 		require.NoError(t, err)
 		var actionResult remoteexecution.ActionResult
 		require.NoError(
@@ -746,7 +746,7 @@ func TestOutputHierarchyUploadOutputs(t *testing.T) {
 		oh, err := builder.NewOutputHierarchy(&remoteexecution.Command{
 			WorkingDirectory:  "foo",
 			OutputDirectories: []string{".."},
-		})
+		}, true)
 		require.NoError(t, err)
 		var actionResult remoteexecution.ActionResult
 		require.NoError(
@@ -793,7 +793,7 @@ func TestOutputHierarchyUploadOutputs(t *testing.T) {
 		oh, err := builder.NewOutputHierarchy(&remoteexecution.Command{
 			WorkingDirectory: "foo",
 			OutputPaths:      []string{".."},
-		})
+		}, false)
 		require.NoError(t, err)
 		var actionResult remoteexecution.ActionResult
 		require.NoError(
@@ -828,7 +828,7 @@ func TestOutputHierarchyUploadOutputs(t *testing.T) {
 		oh, err := builder.NewOutputHierarchy(&remoteexecution.Command{
 			WorkingDirectory:  "",
 			OutputDirectories: []string{"foo"},
-		})
+		}, true)
 		require.NoError(t, err)
 		var actionResult remoteexecution.ActionResult
 		testutil.RequireEqualStatus(
@@ -853,7 +853,7 @@ func TestOutputHierarchyUploadOutputs(t *testing.T) {
 		oh, err := builder.NewOutputHierarchy(&remoteexecution.Command{
 			WorkingDirectory: "",
 			OutputFiles:      []string{"foo"},
-		})
+		}, true)
 		require.NoError(t, err)
 		var actionResult remoteexecution.ActionResult
 		testutil.RequireEqualStatus(
@@ -878,7 +878,7 @@ func TestOutputHierarchyUploadOutputs(t *testing.T) {
 		oh, err := builder.NewOutputHierarchy(&remoteexecution.Command{
 			WorkingDirectory: "",
 			OutputPaths:      []string{"foo"},
-		})
+		}, false)
 		require.NoError(t, err)
 		var actionResult remoteexecution.ActionResult
 		testutil.RequireEqualStatus(
@@ -992,7 +992,7 @@ func TestOutputHierarchyUploadOutputs(t *testing.T) {
 		oh, err := builder.NewOutputHierarchy(&remoteexecution.Command{
 			OutputPaths:           []string{"."},
 			OutputDirectoryFormat: remoteexecution.Command_TREE_AND_DIRECTORY,
-		})
+		}, false)
 		require.NoError(t, err)
 		var actionResult remoteexecution.ActionResult
 		require.NoError(

--- a/pkg/proto/configuration/bb_worker/bb_worker.pb.go
+++ b/pkg/proto/configuration/bb_worker/bb_worker.pb.go
@@ -32,22 +32,23 @@ const (
 )
 
 type ApplicationConfiguration struct {
-	state                          protoimpl.MessageState                    `protogen:"open.v1"`
-	Blobstore                      *blobstore.BlobstoreConfiguration         `protobuf:"bytes,1,opt,name=blobstore,proto3" json:"blobstore,omitempty"`
-	BrowserUrl                     string                                    `protobuf:"bytes,2,opt,name=browser_url,json=browserUrl,proto3" json:"browser_url,omitempty"`
-	MaximumMessageSizeBytes        int64                                     `protobuf:"varint,6,opt,name=maximum_message_size_bytes,json=maximumMessageSizeBytes,proto3" json:"maximum_message_size_bytes,omitempty"`
-	Scheduler                      *grpc.ClientConfiguration                 `protobuf:"bytes,8,opt,name=scheduler,proto3" json:"scheduler,omitempty"`
-	Global                         *global.Configuration                     `protobuf:"bytes,19,opt,name=global,proto3" json:"global,omitempty"`
-	BuildDirectories               []*BuildDirectoryConfiguration            `protobuf:"bytes,20,rep,name=build_directories,json=buildDirectories,proto3" json:"build_directories,omitempty"`
-	FilePool                       *filesystem.FilePoolConfiguration         `protobuf:"bytes,22,opt,name=file_pool,json=filePool,proto3" json:"file_pool,omitempty"`
-	CompletedActionLoggers         []*CompletedActionLoggingConfiguration    `protobuf:"bytes,23,rep,name=completed_action_loggers,json=completedActionLoggers,proto3" json:"completed_action_loggers,omitempty"`
-	OutputUploadConcurrency        int64                                     `protobuf:"varint,24,opt,name=output_upload_concurrency,json=outputUploadConcurrency,proto3" json:"output_upload_concurrency,omitempty"`
-	DirectoryCache                 *cas.CachingDirectoryFetcherConfiguration `protobuf:"bytes,25,opt,name=directory_cache,json=directoryCache,proto3" json:"directory_cache,omitempty"`
-	Prefetching                    *PrefetchingConfiguration                 `protobuf:"bytes,26,opt,name=prefetching,proto3" json:"prefetching,omitempty"`
-	ForceUploadTreesAndDirectories bool                                      `protobuf:"varint,27,opt,name=force_upload_trees_and_directories,json=forceUploadTreesAndDirectories,proto3" json:"force_upload_trees_and_directories,omitempty"`
-	InputDownloadConcurrency       int64                                     `protobuf:"varint,28,opt,name=input_download_concurrency,json=inputDownloadConcurrency,proto3" json:"input_download_concurrency,omitempty"`
-	unknownFields                  protoimpl.UnknownFields
-	sizeCache                      protoimpl.SizeCache
+	state                                  protoimpl.MessageState                    `protogen:"open.v1"`
+	Blobstore                              *blobstore.BlobstoreConfiguration         `protobuf:"bytes,1,opt,name=blobstore,proto3" json:"blobstore,omitempty"`
+	BrowserUrl                             string                                    `protobuf:"bytes,2,opt,name=browser_url,json=browserUrl,proto3" json:"browser_url,omitempty"`
+	MaximumMessageSizeBytes                int64                                     `protobuf:"varint,6,opt,name=maximum_message_size_bytes,json=maximumMessageSizeBytes,proto3" json:"maximum_message_size_bytes,omitempty"`
+	Scheduler                              *grpc.ClientConfiguration                 `protobuf:"bytes,8,opt,name=scheduler,proto3" json:"scheduler,omitempty"`
+	Global                                 *global.Configuration                     `protobuf:"bytes,19,opt,name=global,proto3" json:"global,omitempty"`
+	BuildDirectories                       []*BuildDirectoryConfiguration            `protobuf:"bytes,20,rep,name=build_directories,json=buildDirectories,proto3" json:"build_directories,omitempty"`
+	FilePool                               *filesystem.FilePoolConfiguration         `protobuf:"bytes,22,opt,name=file_pool,json=filePool,proto3" json:"file_pool,omitempty"`
+	CompletedActionLoggers                 []*CompletedActionLoggingConfiguration    `protobuf:"bytes,23,rep,name=completed_action_loggers,json=completedActionLoggers,proto3" json:"completed_action_loggers,omitempty"`
+	OutputUploadConcurrency                int64                                     `protobuf:"varint,24,opt,name=output_upload_concurrency,json=outputUploadConcurrency,proto3" json:"output_upload_concurrency,omitempty"`
+	DirectoryCache                         *cas.CachingDirectoryFetcherConfiguration `protobuf:"bytes,25,opt,name=directory_cache,json=directoryCache,proto3" json:"directory_cache,omitempty"`
+	Prefetching                            *PrefetchingConfiguration                 `protobuf:"bytes,26,opt,name=prefetching,proto3" json:"prefetching,omitempty"`
+	ForceUploadTreesAndDirectories         bool                                      `protobuf:"varint,27,opt,name=force_upload_trees_and_directories,json=forceUploadTreesAndDirectories,proto3" json:"force_upload_trees_and_directories,omitempty"`
+	InputDownloadConcurrency               int64                                     `protobuf:"varint,28,opt,name=input_download_concurrency,json=inputDownloadConcurrency,proto3" json:"input_download_concurrency,omitempty"`
+	SupportLegacyOutputFilesAndDirectories bool                                      `protobuf:"varint,29,opt,name=support_legacy_output_files_and_directories,json=supportLegacyOutputFilesAndDirectories,proto3" json:"support_legacy_output_files_and_directories,omitempty"`
+	unknownFields                          protoimpl.UnknownFields
+	sizeCache                              protoimpl.SizeCache
 }
 
 func (x *ApplicationConfiguration) Reset() {
@@ -169,6 +170,13 @@ func (x *ApplicationConfiguration) GetInputDownloadConcurrency() int64 {
 		return x.InputDownloadConcurrency
 	}
 	return 0
+}
+
+func (x *ApplicationConfiguration) GetSupportLegacyOutputFilesAndDirectories() bool {
+	if x != nil {
+		return x.SupportLegacyOutputFilesAndDirectories
+	}
+	return false
 }
 
 type BuildDirectoryConfiguration struct {
@@ -669,7 +677,7 @@ var File_pkg_proto_configuration_bb_worker_bb_worker_proto protoreflect.FileDesc
 
 const file_pkg_proto_configuration_bb_worker_bb_worker_proto_rawDesc = "" +
 	"\n" +
-	"1pkg/proto/configuration/bb_worker/bb_worker.proto\x12!buildbarn.configuration.bb_worker\x1a6build/bazel/remote/execution/v2/remote_execution.proto\x1a\x1egoogle/protobuf/duration.proto\x1a1pkg/proto/configuration/blobstore/blobstore.proto\x1a%pkg/proto/configuration/cas/cas.proto\x1a/pkg/proto/configuration/eviction/eviction.proto\x1a3pkg/proto/configuration/filesystem/filesystem.proto\x1a8pkg/proto/configuration/filesystem/virtual/virtual.proto\x1a+pkg/proto/configuration/global/global.proto\x1a'pkg/proto/configuration/grpc/grpc.proto\x1a+pkg/proto/resourceusage/resourceusage.proto\"\xe0\b\n" +
+	"1pkg/proto/configuration/bb_worker/bb_worker.proto\x12!buildbarn.configuration.bb_worker\x1a6build/bazel/remote/execution/v2/remote_execution.proto\x1a\x1egoogle/protobuf/duration.proto\x1a1pkg/proto/configuration/blobstore/blobstore.proto\x1a%pkg/proto/configuration/cas/cas.proto\x1a/pkg/proto/configuration/eviction/eviction.proto\x1a3pkg/proto/configuration/filesystem/filesystem.proto\x1a8pkg/proto/configuration/filesystem/virtual/virtual.proto\x1a+pkg/proto/configuration/global/global.proto\x1a'pkg/proto/configuration/grpc/grpc.proto\x1a+pkg/proto/resourceusage/resourceusage.proto\"\xbd\t\n" +
 	"\x18ApplicationConfiguration\x12W\n" +
 	"\tblobstore\x18\x01 \x01(\v29.buildbarn.configuration.blobstore.BlobstoreConfigurationR\tblobstore\x12\x1f\n" +
 	"\vbrowser_url\x18\x02 \x01(\tR\n" +
@@ -684,7 +692,8 @@ const file_pkg_proto_configuration_bb_worker_bb_worker_proto_rawDesc = "" +
 	"\x0fdirectory_cache\x18\x19 \x01(\v2A.buildbarn.configuration.cas.CachingDirectoryFetcherConfigurationR\x0edirectoryCache\x12]\n" +
 	"\vprefetching\x18\x1a \x01(\v2;.buildbarn.configuration.bb_worker.PrefetchingConfigurationR\vprefetching\x12J\n" +
 	"\"force_upload_trees_and_directories\x18\x1b \x01(\bR\x1eforceUploadTreesAndDirectories\x12<\n" +
-	"\x1ainput_download_concurrency\x18\x1c \x01(\x03R\x18inputDownloadConcurrencyJ\x04\b\t\x10\n" +
+	"\x1ainput_download_concurrency\x18\x1c \x01(\x03R\x18inputDownloadConcurrency\x12[\n" +
+	"+support_legacy_output_files_and_directories\x18\x1d \x01(\bR&supportLegacyOutputFilesAndDirectoriesJ\x04\b\t\x10\n" +
 	"J\x04\b\f\x10\rJ\x04\b\x10\x10\x11J\x04\b\x12\x10\x13J\x04\b\x15\x10\x16\"\xbd\x02\n" +
 	"\x1bBuildDirectoryConfiguration\x12^\n" +
 	"\x06native\x18\x01 \x01(\v2D.buildbarn.configuration.bb_worker.NativeBuildDirectoryConfigurationH\x00R\x06native\x12a\n" +

--- a/pkg/proto/configuration/bb_worker/bb_worker.proto
+++ b/pkg/proto/configuration/bb_worker/bb_worker.proto
@@ -155,6 +155,15 @@ message ApplicationConfiguration {
   // This limit applied to the worker process as a whole; not individual
   // worker threads.
   int64 input_download_concurrency = 28;
+
+  // If set, provide support for specifying action outputs using
+  // REv2.0's Command.output_files and Command.output_directories
+  // fields. When not set, only REv2.1's Command.output_paths option is
+  // supported.
+  //
+  // NOTE: This feature is deprecated, and will be removed after
+  // 2026-04-01.
+  bool support_legacy_output_files_and_directories = 29;
 }
 
 message BuildDirectoryConfiguration {


### PR DESCRIPTION
Command.output_paths was added to REv2 in November 2019. At the same time output_files and output_directories were deprecated. At this point there is no excuse for clients to use the old options. Let's place support for the old fields behind a configuration option, so that we can deorbit support for it early next year.