### PR TITLE
Add a winfsp-based vfs implementation

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -893,6 +893,16 @@
                }
             },
             {
+               "if": "matrix.host.platform_name == 'windows_amd64'",
+               "name": "Install WinFSP",
+               "run": "choco install winfsp"
+            },
+            {
+               "if": "matrix.host.platform_name == 'windows_amd64'",
+               "name": "Execute WinFSP Integration Tests",
+               "run": "bazel test --platforms=@rules_go//go/toolchain:windows_amd64 //pkg/filesystem/virtual/winfsp:file_system_integration_test"
+            },
+            {
                "env": {
                   "GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}"
                },

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -107,6 +107,16 @@
                "if": "matrix.host.cross_compile || matrix.host.platform_name == 'windows_amd64'",
                "name": "windows_amd64: build${{ matrix.host.platform_name == 'windows_amd64' && ' and test' || '' }}",
                "run": "bazel ${{ matrix.host.platform_name == 'windows_amd64' && 'test --test_output=errors' || 'build' }} --platforms=@rules_go//go/toolchain:windows_amd64 //..."
+            },
+            {
+               "if": "matrix.host.platform_name == 'windows_amd64'",
+               "name": "Install WinFSP",
+               "run": "choco install winfsp"
+            },
+            {
+               "if": "matrix.host.platform_name == 'windows_amd64'",
+               "name": "Execute WinFSP Integration Tests",
+               "run": "bazel test --platforms=@rules_go//go/toolchain:windows_amd64 //pkg/filesystem/virtual/winfsp:file_system_integration_test"
             }
          ],
          "strategy": {

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,7 +25,7 @@ git_override(
 
 git_override(
     module_name = "com_github_buildbarn_bb_storage",
-    commit = "da347f4e972b0a2b43c1c2cc30a6835b4d941355",
+    commit = "fd11d3e1b0b435165c5e37254ac5d265e7999cb8",
     remote = "https://github.com/buildbarn/bb-storage.git",
 )
 
@@ -59,6 +59,7 @@ go_deps.from_file(go_mod = "//:go.mod")
 use_repo(
     go_deps,
     "cc_mvdan_gofumpt",
+    "com_github_aegistudio_go_winfsp",
     "com_github_bazelbuild_buildtools",
     "com_github_golang_protobuf",
     "com_github_google_uuid",
@@ -166,3 +167,16 @@ oci.pull(
     ],
 )
 use_repo(oci, "busybox", "busybox_linux_amd64", "busybox_linux_arm64_v8")
+
+http_archive(
+    name = "com_github_winfsp_winfsp_tests",
+    build_file_content = """
+filegroup(
+    name = "winfsp_tests_x64",
+    srcs = ["winfsp-tests-x64.exe"],
+    visibility = ["//visibility:public"],
+)
+""",
+    integrity = "sha256-DPxoeRcDyA+Wxynr04tjGH3lPhm6ocYDpwWdbqh8X1I=",
+    url = "https://github.com/winfsp/winfsp/releases/download/v2.1/winfsp-tests-2.1.25156.zip",
+)

--- a/cmd/bb_virtual_tmp/main.go
+++ b/cmd/bb_virtual_tmp/main.go
@@ -59,14 +59,15 @@ func main() {
 			"bb_virtual_tmp",
 			/* rootDirectory = */ virtual_configuration.LongAttributeCaching,
 			/* childDirectories = */ virtual_configuration.LongAttributeCaching,
-			/* leaves = */ virtual_configuration.NoAttributeCaching)
+			/* leaves = */ virtual_configuration.NoAttributeCaching,
+			/* caseSensitive = */ true)
 		if err != nil {
 			return util.StatusWrap(err, "Failed to create virtual file system mount")
 		}
 		if err := mount.Expose(
 			siblingsGroup,
 			handleAllocator.New().AsStatelessDirectory(
-				virtual.NewStaticDirectory(map[path.Component]virtual.DirectoryChild{
+				virtual.NewStaticDirectory(virtual.CaseSensitiveComponentNormalizer, map[path.Component]virtual.DirectoryChild{
 					path.MustNewComponent("tmp"): virtual.DirectoryChild{}.
 						FromLeaf(handleAllocator.New().AsLinkableLeaf(userSettableSymlink)),
 				}))); err != nil {

--- a/cmd/bb_worker/main.go
+++ b/cmd/bb_worker/main.go
@@ -191,7 +191,8 @@ func main() {
 					"bb_worker",
 					/* rootDirectory = */ virtual_configuration.ShortAttributeCaching,
 					/* childDirectories = */ virtual_configuration.LongAttributeCaching,
-					/* leaves = */ virtual_configuration.LongAttributeCaching)
+					/* leaves = */ virtual_configuration.LongAttributeCaching,
+					!backend.Virtual.CaseInsensitive)
 				if err != nil {
 					return util.StatusWrap(err, "Failed to create build directory mount")
 				}
@@ -209,6 +210,12 @@ func main() {
 				if backend.Virtual.ShuffleDirectoryListings {
 					initialContentsSorter = virtual.Shuffle
 				}
+
+				normalizer := virtual.CaseSensitiveComponentNormalizer
+				if backend.Virtual.CaseInsensitive {
+					normalizer = virtual.CaseInsensitiveComponentNormalizer
+				}
+
 				symlinkFactory = virtual.NewHandleAllocatingSymlinkFactory(
 					virtual.BaseSymlinkFactory,
 					handleAllocator.New())
@@ -227,6 +234,7 @@ func main() {
 					initialContentsSorter,
 					hiddenFilesPattern,
 					clock.SystemClock,
+					normalizer,
 					/* defaultAttributesSetter = */ func(requested virtual.AttributesMask, attributes *virtual.Attributes) {
 						// No need to set ownership
 						// attributes on the top-level

--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,11 @@ replace github.com/hanwen/go-fuse/v2 => github.com/hanwen/go-fuse/v2 v2.5.1
 
 require (
 	cloud.google.com/go/longrunning v0.6.7
+	github.com/aegistudio/go-winfsp v1.0.1
 	github.com/bazelbuild/buildtools v0.0.0-20250715102656-62b9413b08bb
 	github.com/bazelbuild/remote-apis v0.0.0-20250728120203-e94a7ece2a1e
-	github.com/buildbarn/bb-storage v0.0.0-20250819084849-da347f4e972b
+	github.com/bazelbuild/rules_go v0.56.1
+	github.com/buildbarn/bb-storage v0.0.0-20250819193852-fd11d3e1b0b4
 	github.com/buildbarn/go-xdr v0.0.0-20240702182809-236788cf9e89
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
@@ -91,6 +93,7 @@ require (
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/lazybeaver/xorshift v0.0.0-20170702203709-ce511d4823dd // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.53.0/go.mod h1:jUZ5LYlw40WMd07qxcQJD5M40aUxrfwqQX1g7zxYnrQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0 h1:Ron4zCA/yk6U7WOBXhTJcDpsUBG9npumK6xw2auFltQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0/go.mod h1:cSgYe11MCNYunTnRXrKiR/tHc0eoKjICUuWpNZoVCOo=
+github.com/aegistudio/go-winfsp v1.0.1 h1:XoI3L0r5l9uRKefjiBzEvcsz37YFW+BN8/Do37gBoSQ=
+github.com/aegistudio/go-winfsp v1.0.1/go.mod h1:NLiW7JmEKU0TaN19ymrywYtiA9E0tEDfh+sJU4G/Tgw=
 github.com/aohorodnyk/mimeheader v0.0.6 h1:WCV4NQjtbqnd2N3FT5MEPesan/lfvaLYmt5v4xSaX/M=
 github.com/aohorodnyk/mimeheader v0.0.6/go.mod h1:/Gd3t3vszyZYwjNJo2qDxoftZjjVzMdkQZxkiINp3vM=
 github.com/aws/aws-sdk-go-v2 v1.38.0 h1:UCRQ5mlqcFk9HJDIqENSLR3wiG1VTWlyUfLDEvY7RxU=
@@ -72,11 +74,13 @@ github.com/bazelbuild/buildtools v0.0.0-20250715102656-62b9413b08bb h1:KCEfAAZ5h
 github.com/bazelbuild/buildtools v0.0.0-20250715102656-62b9413b08bb/go.mod h1:PLNUetjLa77TCCziPsz0EI8a6CUxgC+1jgmWv0H25tg=
 github.com/bazelbuild/remote-apis v0.0.0-20250728120203-e94a7ece2a1e h1:P0oJ1MpCJTu4lDRbb00aVaPTcDvaQ1uQFsVVBeqttIc=
 github.com/bazelbuild/remote-apis v0.0.0-20250728120203-e94a7ece2a1e/go.mod h1:/xo1pn3QkEL2JXrLeK30jvjVR/zXM9H8EqcWb/l5/A0=
+github.com/bazelbuild/rules_go v0.56.1 h1:YOyW1J8kdvJl1AzlWrR+qikC6EPiFVbT4l1gjTBfXT0=
+github.com/bazelbuild/rules_go v0.56.1/go.mod h1:T90Gpyq4HDFlsrvtQa2CBdHNJ2P4rAu/uUTmQbanzf0=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/buildbarn/bb-storage v0.0.0-20250819084849-da347f4e972b h1:GIFwvHwpRy7AWqcm4TTzQpNisJTYs8tYKJ30zHxEUeA=
-github.com/buildbarn/bb-storage v0.0.0-20250819084849-da347f4e972b/go.mod h1:HetfamALiIPfoxhYb1f9v7Upxl3s01K8zwJ/3QZr5hw=
+github.com/buildbarn/bb-storage v0.0.0-20250819193852-fd11d3e1b0b4 h1:OxpG/cb7Xxfz0HM0oM1320o45mz2suKt05KlEmzCjg8=
+github.com/buildbarn/bb-storage v0.0.0-20250819193852-fd11d3e1b0b4/go.mod h1:HetfamALiIPfoxhYb1f9v7Upxl3s01K8zwJ/3QZr5hw=
 github.com/buildbarn/go-sha256tree v0.0.0-20250310211320-0f70f20e855b h1:IKUxixGBm9UxobU7c248z0BF0ojG19uoSLz8MFZM/KA=
 github.com/buildbarn/go-sha256tree v0.0.0-20250310211320-0f70f20e855b/go.mod h1:e7g3/yWApcg+PpDqd4eQEEV8pexQmfCgK3frP+1Wuvk=
 github.com/buildbarn/go-xdr v0.0.0-20240702182809-236788cf9e89 h1:Wtpgk4CIkoEJ7Qx3BwjaMp3TOVv834heqyCC9jMKStM=
@@ -189,6 +193,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/filesystem/virtual/BUILD.bazel
+++ b/pkg/filesystem/virtual/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "cas_initial_contents_fetcher.go",
         "character_device_factory.go",
         "child.go",
+        "component_normalizer.go",
         "directory.go",
         "empty_initial_contents_fetcher.go",
         "file_allocator.go",

--- a/pkg/filesystem/virtual/component_normalizer.go
+++ b/pkg/filesystem/virtual/component_normalizer.go
@@ -1,0 +1,38 @@
+package virtual
+
+import (
+	"strings"
+
+	"github.com/buildbarn/bb-storage/pkg/filesystem/path"
+)
+
+// NormalizedComponent is a normalized version of a path.Component.
+// The meaning of normalized depends on what ComponentNormalizer was used to
+// normalize the path.
+type NormalizedComponent string
+
+// ComponentNormalizer is an interface for implementing normalization of
+// path.Component.
+type ComponentNormalizer interface {
+	Normalize(path.Component) NormalizedComponent
+}
+
+type caseSensitiveComponentNormalizer struct{}
+
+func (caseSensitiveComponentNormalizer) Normalize(c path.Component) NormalizedComponent {
+	return NormalizedComponent(c.String())
+}
+
+// CaseSensitiveComponentNormalizer is a ComponentNormalizer that normalizes
+// path components in a case-sensitive manner.
+var CaseSensitiveComponentNormalizer ComponentNormalizer = caseSensitiveComponentNormalizer{}
+
+type caseInsensitiveComponentNormalizer struct{}
+
+func (caseInsensitiveComponentNormalizer) Normalize(c path.Component) NormalizedComponent {
+	return NormalizedComponent(strings.ToLower(c.String()))
+}
+
+// CaseInsensitiveComponentNormalizer is a ComponentNormalizer that normalizes
+// path components in a case-insensitive manner.
+var CaseInsensitiveComponentNormalizer ComponentNormalizer = caseInsensitiveComponentNormalizer{}

--- a/pkg/filesystem/virtual/configuration/BUILD.bazel
+++ b/pkg/filesystem/virtual/configuration/BUILD.bazel
@@ -11,6 +11,8 @@ go_library(
         "nfsv4_mount_disabled.go",
         "nfsv4_mount_linux.go",
         "remove_stale_mounts.go",
+        "winfsp_mount_disabled.go",
+        "winfsp_mount_windows.go",
     ],
     importpath = "github.com/buildbarn/bb-remote-execution/pkg/filesystem/virtual/configuration",
     visibility = ["//visibility:public"],
@@ -48,6 +50,9 @@ go_library(
             "@com_github_buildbarn_bb_storage//pkg/filesystem",
             "@com_github_hanwen_go_fuse_v2//fuse",
             "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:windows": [
+            "//pkg/filesystem/virtual/winfsp",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/filesystem/virtual/configuration/winfsp_mount_disabled.go
+++ b/pkg/filesystem/virtual/configuration/winfsp_mount_disabled.go
@@ -1,0 +1,16 @@
+//go:build darwin || freebsd || linux
+// +build darwin freebsd linux
+
+package configuration
+
+import (
+	"github.com/buildbarn/bb-remote-execution/pkg/filesystem/virtual"
+	"github.com/buildbarn/bb-storage/pkg/program"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (m *winfspMount) Expose(terminationGroup program.Group, rootDirectory virtual.Directory) error {
+	return status.Error(codes.Unimplemented, "WinFSP is not supported on this platform")
+}

--- a/pkg/filesystem/virtual/configuration/winfsp_mount_windows.go
+++ b/pkg/filesystem/virtual/configuration/winfsp_mount_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+// +build windows
+
+package configuration
+
+import (
+	"context"
+
+	"github.com/buildbarn/bb-remote-execution/pkg/filesystem/virtual"
+	"github.com/buildbarn/bb-remote-execution/pkg/filesystem/virtual/winfsp"
+	"github.com/buildbarn/bb-storage/pkg/program"
+)
+
+func (m *winfspMount) Expose(terminationGroup program.Group, rootDirectory virtual.Directory) error {
+	winfspFs := winfsp.NewFileSystem(rootDirectory, m.caseSensitive)
+	fs, err := winfspFs.Mount(m.fsName, m.mountPath)
+	if err != nil {
+		return err
+	}
+	// Automatically unmount upon shutdown.
+	terminationGroup.Go(func(ctx context.Context, siblingsGroup, dependenciesGroup program.Group) error {
+		<-ctx.Done()
+		fs.Unmount()
+		return nil
+	})
+	return nil
+}

--- a/pkg/filesystem/virtual/in_memory_prepopulated_directory_test.go
+++ b/pkg/filesystem/virtual/in_memory_prepopulated_directory_test.go
@@ -57,7 +57,7 @@ func TestInMemoryPrepopulatedDirectoryLookupChildNonExistent(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	_, err := d.LookupChild(path.MustNewComponent("nonexistent"))
 	require.True(t, os.IsNotExist(err))
@@ -72,7 +72,7 @@ func TestInMemoryPrepopulatedDirectoryLookupChildFile(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	leaf := mock.NewMockLinkableLeaf(ctrl)
 	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
@@ -93,7 +93,7 @@ func TestInMemoryPrepopulatedDirectoryLookupChildDirectory(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
@@ -117,7 +117,7 @@ func TestInMemoryPrepopulatedDirectoryLookupAllChildrenFailure(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	initialContentsFetcher := mock.NewMockInitialContentsFetcher(ctrl)
@@ -150,7 +150,7 @@ func TestInMemoryPrepopulatedDirectoryLookupAllChildrenSuccess(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// Populate the directory with files and directories.
 	leaf1 := mock.NewMockLinkableLeaf(ctrl)
@@ -189,7 +189,7 @@ func TestInMemoryPrepopulatedDirectoryReadDir(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// Prepare file system.
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
@@ -228,7 +228,7 @@ func TestInMemoryPrepopulatedDirectoryRemoveNonExistent(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	require.True(t, os.IsNotExist(d.Remove(path.MustNewComponent("nonexistent"))))
 }
@@ -242,7 +242,7 @@ func TestInMemoryPrepopulatedDirectoryRemoveDirectory(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	dHandle := inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	subdirHandle := inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
@@ -265,7 +265,7 @@ func TestInMemoryPrepopulatedDirectoryRemoveDirectoryNotEmpty(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	initialContentsFetcher := mock.NewMockInitialContentsFetcher(ctrl)
@@ -289,7 +289,7 @@ func TestInMemoryPrepopulatedDirectoryRemoveFile(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	dHandle := inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	leaf := mock.NewMockLinkableLeaf(ctrl)
 	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
@@ -313,7 +313,7 @@ func TestInMemoryPrepopulatedDirectoryCreateChildrenSuccess(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// Merge another directory and file into it.
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
@@ -374,7 +374,7 @@ func TestInMemoryPrepopulatedDirectoryCreateChildrenInRemovedDirectory(t *testin
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	dHandle := inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// Create a reference to a removed child directory.
 	childHandle := inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
@@ -398,7 +398,7 @@ func TestInMemoryPrepopulatedDirectoryInstallHooks(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter1 := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator1, symlinkFactory1, errorLogger1, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter1.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator1, symlinkFactory1, errorLogger1, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter1.Call)
 	fileAllocator2 := mock.NewMockFileAllocator(ctrl)
 	errorLogger2 := mock.NewMockErrorLogger(ctrl)
 	defaultAttributesSetter2 := mock.NewMockDefaultAttributesSetter(ctrl)
@@ -446,7 +446,7 @@ func TestInMemoryPrepopulatedDirectoryFilterChildren(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	dHandle := inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// In the initial state, InMemoryPrepopulatedDirectory will have
 	// an EmptyInitialContentsFetcher associated with it.
@@ -504,6 +504,42 @@ func TestInMemoryPrepopulatedDirectoryFilterChildren(t *testing.T) {
 	require.NoError(t, d.FilterChildren(childFilter4.Call))
 }
 
+func TestInMemoryPrepopulatedDirectoryCaseInsensitive(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	fileAllocator := mock.NewMockFileAllocator(ctrl)
+	symlinkFactory := mock.NewMockSymlinkFactory(ctrl)
+	errorLogger := mock.NewMockErrorLogger(ctrl)
+	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
+	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
+	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseInsensitiveComponentNormalizer, defaultAttributesSetter.Call)
+
+	leaf := mock.NewMockLinkableLeaf(ctrl)
+	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
+		path.MustNewComponent("MyFile"): virtual.InitialChild{}.FromLeaf(leaf),
+	}, false))
+
+	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
+	_, err := d.CreateAndEnterPrepopulatedDirectory(path.MustNewComponent("MyDir"))
+	require.NoError(t, err)
+
+	t.Run("LookupChildFileWithDifferentCase", func(t *testing.T) {
+		child, err := d.LookupChild(path.MustNewComponent("myfile"))
+		require.NoError(t, err)
+		require.Equal(t, virtual.PrepopulatedDirectoryChild{}.FromLeaf(leaf), child)
+	})
+
+	t.Run("LookupChildDirectoryWithDifferentCase", func(t *testing.T) {
+		child, err := d.LookupChild(path.MustNewComponent("MYDIR"))
+		require.NoError(t, err)
+
+		childDirectory, childLeaf := child.GetPair()
+		require.NotNil(t, childDirectory)
+		require.Nil(t, childLeaf)
+	})
+}
+
 func TestInMemoryPrepopulatedDirectoryVirtualOpenChildFileExists(t *testing.T) {
 	ctrl, ctx := gomock.WithContext(context.Background(), t)
 
@@ -513,7 +549,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualOpenChildFileExists(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// Create a file at the desired target location.
 	leaf := mock.NewMockLinkableLeaf(ctrl)
@@ -543,7 +579,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualOpenChildDirectoryExists(t *testing
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// Create a directory at the desired target location.
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
@@ -575,7 +611,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualOpenChildAllocationFailure(t *testi
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// File allocation errors should translate to EIO. The actual
 	// error should get forwarded to the error logger.
@@ -600,7 +636,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualOpenChildInRemovedDirectory(t *test
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	dHandle := inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// Create a reference to a removed child directory.
 	childHandle := inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
@@ -650,7 +686,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualOpenChildSuccess(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// Creation of the directory should fully succeed. The file
 	// should be present within the directory afterwards.
@@ -691,7 +727,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualGetAttributes(t *testing.T) {
 	clock := mock.NewMockClock(ctrl)
 	clock.EXPECT().Now().Return(time.Unix(1000, 0))
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	defaultAttributesSetter.EXPECT().Call(inMemoryPrepopulatedDirectoryAttributesMask, gomock.Any()).
 		Do(func(attributesMask virtual.AttributesMask, attributes *virtual.Attributes) {
@@ -727,7 +763,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualLinkExists(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// Attempting to link to a file that already exists should fail.
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
@@ -749,7 +785,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualLinkInRemovedDirectory(t *testing.T
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	dHandle := inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// Create a reference to a removed child directory.
 	childHandle := inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
@@ -774,7 +810,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualLinkNotLinkableLeaf(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// Trying to link a file that does not implement LinkableLeaf is
 	// not possible. We can only store leaf nodes that implement
@@ -794,7 +830,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualLinkStale(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// Attempting to link a file that has already been removed
 	// should fail.
@@ -824,7 +860,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualLinkSuccess(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// We should return the attributes of the existing leaf.
 	var attr virtual.Attributes
@@ -848,7 +884,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualLookup(t *testing.T) {
 	clock := mock.NewMockClock(ctrl)
 	clock.EXPECT().Now().Return(time.Unix(1000, 0))
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// Create an example directory and file that we'll try to look up.
 	subdirHandle := inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
@@ -924,7 +960,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualMkdir(t *testing.T) {
 	clock := mock.NewMockClock(ctrl)
 	clock.EXPECT().Now().Return(time.Unix(1000, 0))
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	t.Run("FailureInitialContentsFetcher", func(t *testing.T) {
 		// Create a subdirectory that has an initial contents fetcher.
@@ -1011,7 +1047,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualMknodExists(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// Files may not be overwritten by mknod().
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
@@ -1032,7 +1068,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualMknodSuccess(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// Create a FIFO and a UNIX domain socket.
 	fifoHandleAllocation := mock.NewMockStatefulHandleAllocation(ctrl)
@@ -1106,7 +1142,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualReadDir(t *testing.T) {
 	clock := mock.NewMockClock(ctrl)
 	clock.EXPECT().Now().Return(time.Unix(1000, 0))
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// Populate the directory with subdirectory that is
 	// uninitialized and a file.
@@ -1178,7 +1214,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualRenameSelfDirectory(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// Renaming a directory to itself should be permitted, even when
 	// it is not empty.
@@ -1217,7 +1253,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualRenameSelfFile(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	leaf := mock.NewMockLinkableLeaf(ctrl)
 	require.NoError(t, d.CreateChildren(map[path.Component]virtual.InitialChild{
@@ -1281,7 +1317,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualRenameDirectoryInRemovedDirectory(t
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	dHandle := inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// Create a reference to a removed child directory.
 	childHandle := inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
@@ -1316,7 +1352,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualRenameFileInRemovedDirectory(t *tes
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	dHandle := inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// Create a reference to a removed child directory.
 	childHandle := inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
@@ -1359,7 +1395,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualRenameDirectoryTwice(t *testing.T) 
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	// Create two empty directories.
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
@@ -1419,7 +1455,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualRenameCrossDevice1(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d1 := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d1 := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	d2 := mock.NewMockVirtualDirectory(ctrl)
 
@@ -1439,7 +1475,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualRenameCrossDevice2(t *testing.T) {
 	handleAllocator1 := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator1)
 	defaultAttributesSetter1 := mock.NewMockDefaultAttributesSetter(ctrl)
-	d1 := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator1, symlinkFactory1, errorLogger1, handleAllocator1, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter1.Call)
+	d1 := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator1, symlinkFactory1, errorLogger1, handleAllocator1, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter1.Call)
 
 	fileAllocator2 := mock.NewMockFileAllocator(ctrl)
 	symlinkFactory2 := mock.NewMockSymlinkFactory(ctrl)
@@ -1447,7 +1483,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualRenameCrossDevice2(t *testing.T) {
 	handleAllocator2 := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator2)
 	defaultAttributesSetter2 := mock.NewMockDefaultAttributesSetter(ctrl)
-	d2 := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator2, symlinkFactory2, errorLogger2, handleAllocator2, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter2.Call)
+	d2 := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator2, symlinkFactory2, errorLogger2, handleAllocator2, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter2.Call)
 
 	// It should not be possible to rename directories from one
 	// hierarchy to another, as this completely messes up
@@ -1494,7 +1530,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualRemove(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	t.Run("NotFound", func(t *testing.T) {
 		// Attempting to remove a file that does not exist.
@@ -1611,7 +1647,7 @@ func TestInMemoryPrepopulatedDirectoryVirtualSymlink(t *testing.T) {
 	handleAllocator := mock.NewMockStatefulHandleAllocator(ctrl)
 	inMemoryPrepopulatedDirectoryExpectMkdir(ctrl, handleAllocator)
 	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
-	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, defaultAttributesSetter.Call)
+	d := virtual.NewInMemoryPrepopulatedDirectory(fileAllocator, symlinkFactory, errorLogger, handleAllocator, sort.Sort, hiddenFilesPatternForTesting.MatchString, clock.SystemClock, virtual.CaseSensitiveComponentNormalizer, defaultAttributesSetter.Call)
 
 	t.Run("FailureInitialContentsFetcher", func(t *testing.T) {
 		// Create a subdirectory that has an initial contents fetcher.

--- a/pkg/filesystem/virtual/winfsp/BUILD.bazel
+++ b/pkg/filesystem/virtual/winfsp/BUILD.bazel
@@ -1,0 +1,87 @@
+# gazelle:go_test file
+
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "winfsp",
+    srcs = [
+        "file_system.go",
+        "opened_files_pool.go",
+    ],
+    importpath = "github.com/buildbarn/bb-remote-execution/pkg/filesystem/virtual/winfsp",
+    visibility = ["//visibility:public"],
+    deps = select({
+        "@rules_go//go/platform:windows": [
+            "//pkg/filesystem/virtual",
+            "@com_github_aegistudio_go_winfsp//:go-winfsp",
+            "@com_github_aegistudio_go_winfsp//filetime",
+            "@com_github_buildbarn_bb_storage//pkg/filesystem",
+            "@com_github_buildbarn_bb_storage//pkg/filesystem/path",
+            "@com_github_buildbarn_bb_storage//pkg/filesystem/windowsext",
+            "@com_github_buildbarn_bb_storage//pkg/util",
+            "@org_golang_x_sys//windows",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+go_test(
+    name = "file_system_test",
+    srcs = select({
+        "@rules_go//go/platform:windows": [
+            "file_system_test.go",
+        ],
+        "//conditions:default": [],
+    }),
+    deps = select({
+        "@rules_go//go/platform:windows": [
+            ":winfsp",
+            "//internal/mock",
+            "//pkg/filesystem/virtual",
+            "@com_github_aegistudio_go_winfsp//:go-winfsp",
+            "@com_github_aegistudio_go_winfsp//filetime",
+            "@com_github_buildbarn_bb_storage//pkg/filesystem",
+            "@com_github_buildbarn_bb_storage//pkg/filesystem/path",
+            "@com_github_buildbarn_bb_storage//pkg/filesystem/windowsext",
+            "@com_github_stretchr_testify//require",
+            "@org_golang_x_sys//windows",
+            "@org_uber_go_mock//gomock",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+go_test(
+    name = "file_system_integration_test",
+    srcs = select({
+        "@rules_go//go/platform:windows": [
+            "file_system_integration_test.go",
+        ],
+        "//conditions:default": [],
+    }),
+    data = select({
+        "@rules_go//go/platform:windows": [
+            "@com_github_winfsp_winfsp_tests//:winfsp_tests_x64",
+        ],
+        "//conditions:default": [],
+    }),
+    tags = ["manual"],
+    deps = select({
+        "@rules_go//go/platform:windows": [
+            "//pkg/filesystem",
+            "//pkg/filesystem/pool",
+            "//pkg/filesystem/virtual",
+            "//pkg/filesystem/virtual/configuration",
+            "//pkg/proto/configuration/filesystem/virtual",
+            "@com_github_aegistudio_go_winfsp//:go-winfsp",
+            "@com_github_buildbarn_bb_storage//pkg/blockdevice",
+            "@com_github_buildbarn_bb_storage//pkg/clock",
+            "@com_github_buildbarn_bb_storage//pkg/program",
+            "@com_github_buildbarn_bb_storage//pkg/util",
+            "@com_github_stretchr_testify//require",
+            "@org_golang_x_sys//windows",
+            "@rules_go//go/runfiles",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/pkg/filesystem/virtual/winfsp/file_system.go
+++ b/pkg/filesystem/virtual/winfsp/file_system.go
@@ -1,0 +1,1480 @@
+//go:build windows
+// +build windows
+
+package winfsp
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+	"unsafe"
+
+	ffi "github.com/aegistudio/go-winfsp"
+	"github.com/aegistudio/go-winfsp/filetime"
+	"github.com/buildbarn/bb-remote-execution/pkg/filesystem/virtual"
+	"github.com/buildbarn/bb-storage/pkg/filesystem"
+	path "github.com/buildbarn/bb-storage/pkg/filesystem/path"
+	"github.com/buildbarn/bb-storage/pkg/filesystem/windowsext"
+	"github.com/buildbarn/bb-storage/pkg/util"
+
+	"golang.org/x/sys/windows"
+)
+
+// Some notes on locking.
+//
+// We're using WinFSP's default concurrency mode, which is
+// FSP_FILE_SYSTEM_OPERATION_GUARD_STRATEGY_FINE. This means that WinFSP will
+// effectively use a single sync.RWMutex. Operations acquire this as follows:
+//   - Writers: SetVolumeLabel, Flush(Volume), Create, Cleanup(Delete),
+//     SetInformation(Rename).
+//   - Readers: GetVolumeInfo, Open, SetInformation(Disposition),
+//     ReadDirectory.
+// All other operations do not acquire any locks. However, WinFSP still applies
+// a sync.RWLock lock per individual file (inside the WinFSP driver itself), so
+// concurrent reads/writes/etc. are still possible, but not in a conflicting
+// way on the same file.
+//
+// On Windows there are quite a few different operations that might conflict.
+// For example, you need to prevent deletion of files if they're open, and also
+// enforce sharing modes when opening files. Thankfully, WinFSP does all of
+// this for us.
+//
+// In quite a few places in this implementation, we have to perform several
+// operations sequentially that really ought to be done atomically. For
+// example, in the implementation of Write, if we should write at the end
+// we really ought to get the size of the file and perform the write
+// atomically, but the VFS does not provide enough locking to do this. In
+// general we rely on the fact that WinFSP does RW locking above us, and we
+// assume that the VFS implementation will not be trying to concurrently
+// write to the same file. That will be true if this is bb_worker and it's
+// trying to fetch inputs to a build action, but wouldn't if the VFS was
+// being used for something more elaborate.
+
+type FileSystem struct {
+	caseSensitive bool
+	rootDirectory virtual.Directory
+	openFiles     openedNodesPool
+
+	// This does not need to be locked; WinFSP enforces a read/write lock.
+	label []uint16
+}
+
+func NewFileSystem(rootDirectory virtual.Directory, caseSensitive bool) *FileSystem {
+	return &FileSystem{
+		caseSensitive: caseSensitive,
+		rootDirectory: rootDirectory,
+		openFiles:     newOpenedNodesPool(),
+	}
+}
+
+func (fs *FileSystem) Mount(fsName, mountpoint string) (*ffi.FileSystem, error) {
+	// debugHandle, err := syscall.GetStdHandle(syscall.STD_ERROR_HANDLE)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// err = ffi.DebugLogSetHandle(debugHandle)
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	var attributes uint32 = ffi.FspFSAttributeUmNoReparsePointsDirCheck
+	attributes |= ffi.FspFSAttributeCasePreservedNames
+
+	fileSystem, err := ffi.Mount(
+		fs,
+		mountpoint,
+		ffi.Attributes(attributes),
+		ffi.CaseSensitive(fs.caseSensitive),
+		// ffi.Debug(true),
+		ffi.FileSystemName(fsName),
+		ffi.SectorSize(512, 1),
+	)
+	if err != nil {
+		return nil, util.StatusWrap(err, "Failed to mount WinFSP file system")
+	}
+	return fileSystem, nil
+}
+
+// AttributesMaskForWinFSPAttr is the attributes mask to use for
+// VirtualGetAttributes() to populate all relevant fields of
+// FSP_FSCTL_FILE_INFO.
+const AttributesMaskForWinFSPAttr = virtual.AttributesMaskDeviceNumber |
+	virtual.AttributesMaskFileType |
+	virtual.AttributesMaskInodeNumber |
+	virtual.AttributesMaskLastDataModificationTime |
+	virtual.AttributesMaskLinkCount |
+	virtual.AttributesMaskOwnerGroupID |
+	virtual.AttributesMaskOwnerUserID |
+	virtual.AttributesMaskPermissions |
+	virtual.AttributesMaskSizeBytes
+
+// unsupportedCreateOptions are the options that are not supported.
+const unsupportedCreateOptions = windows.FILE_CREATE_TREE_CONNECTION |
+	windows.FILE_NO_EA_KNOWLEDGE |
+	windows.FILE_OPEN_BY_FILE_ID |
+	windows.FILE_RESERVE_OPFILTER |
+	windows.FILE_OPEN_REQUIRING_OPLOCK |
+	windows.FILE_COMPLETE_IF_OPLOCKED
+
+const fileAndDirectoryFlag = windows.FILE_DIRECTORY_FILE | windows.FILE_NON_DIRECTORY_FILE
+
+// Attributes we support being set via SetBasicInfo.
+const setBasicInfoSupportedAttributes = windows.FILE_ATTRIBUTE_DIRECTORY |
+	windows.FILE_ATTRIBUTE_NORMAL |
+	windows.FILE_ATTRIBUTE_READONLY
+
+// The Unix Epoch as a Windows FILETIME.
+const unixEpochAsFiletime = 116444736000000000
+
+var (
+	// Stores the current processes' uid and gid, calculated once.
+	currentUserID  *windows.SID
+	currentGroupID *windows.SID
+	userInfoError  error
+	userInfoOnce   sync.Once
+
+	// Stores the everyone SID, calculated once.
+	everyoneSid      *windows.SID
+	everyoneSidError error
+	everyoneSidOnce  sync.Once
+)
+
+func calculateCurrentUserAndGroup() (uid, gid *windows.SID, err error) {
+	token := windows.GetCurrentProcessToken()
+
+	user, err := token.GetTokenUser()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	group, err := token.GetTokenPrimaryGroup()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return user.User.Sid, group.PrimaryGroup, nil
+}
+
+func getCurrentProcessUserAndGroup() (uid, gid *windows.SID, err error) {
+	userInfoOnce.Do(func() {
+		currentUserID, currentGroupID, userInfoError = calculateCurrentUserAndGroup()
+	})
+	return currentUserID, currentGroupID, userInfoError
+}
+
+func getEveryoneSid() (*windows.SID, error) {
+	everyoneSidOnce.Do(func() {
+		everyoneSid, everyoneSidError = windows.CreateWellKnownSid(windows.WinWorldSid)
+	})
+	return everyoneSid, everyoneSidError
+}
+
+func toNTStatus(status virtual.Status) windows.NTStatus {
+	switch status {
+	case virtual.StatusOK:
+		return windows.STATUS_SUCCESS
+	case virtual.StatusErrAccess:
+		return windows.STATUS_ACCESS_DENIED
+	case virtual.StatusErrBadHandle:
+		return windows.STATUS_INVALID_HANDLE
+	case virtual.StatusErrExist:
+		return windows.STATUS_OBJECT_NAME_COLLISION
+	case virtual.StatusErrInval:
+		return windows.STATUS_INVALID_PARAMETER
+	case virtual.StatusErrIO:
+		return windows.STATUS_UNEXPECTED_IO_ERROR
+	case virtual.StatusErrIsDir:
+		return windows.STATUS_FILE_IS_A_DIRECTORY
+	case virtual.StatusErrNoEnt:
+		return windows.STATUS_OBJECT_NAME_NOT_FOUND
+	case virtual.StatusErrNotDir:
+		return windows.STATUS_NOT_A_DIRECTORY
+	case virtual.StatusErrNotEmpty:
+		return windows.STATUS_DIRECTORY_NOT_EMPTY
+	case virtual.StatusErrNXIO:
+		return windows.STATUS_NO_SUCH_DEVICE
+	case virtual.StatusErrPerm:
+		return windows.STATUS_ACCESS_DENIED
+	case virtual.StatusErrROFS:
+		return windows.STATUS_MEDIA_WRITE_PROTECTED
+	case virtual.StatusErrStale:
+		return windows.STATUS_OBJECT_NAME_NOT_FOUND
+	case virtual.StatusErrSymlink:
+		return windows.STATUS_REPARSE
+	case virtual.StatusErrWrongType:
+		return windows.STATUS_OBJECT_TYPE_MISMATCH
+	case virtual.StatusErrXDev:
+		return windows.STATUS_NOT_SUPPORTED
+	default:
+		// For any other status, we return a generic error.
+		return windows.STATUS_UNSUCCESSFUL
+	}
+}
+
+func toShareMask(grantedAccess uint32) virtual.ShareMask {
+	var shareMask virtual.ShareMask
+	if grantedAccess&windows.FILE_READ_DATA != 0 {
+		shareMask |= virtual.ShareMaskRead
+	}
+	if grantedAccess&(windows.FILE_WRITE_DATA|windows.FILE_APPEND_DATA) != 0 {
+		shareMask |= virtual.ShareMaskWrite
+	}
+	return shareMask
+}
+
+// Convert FILETIME to a time.Time object.
+func filetimeToTime(ft uint64) time.Time {
+	nanoseconds := int64(ft-unixEpochAsFiletime) * 100
+	result := time.Unix(0, nanoseconds).UTC()
+	return result
+}
+
+func toVirtualAttributes(leaf virtual.DirectoryChild, attribute uint32, newAttributes *virtual.Attributes, attributesMask *virtual.AttributesMask) error {
+	if attribute != windows.INVALID_FILE_ATTRIBUTES {
+		if attribute&^setBasicInfoSupportedAttributes != 0 {
+			return windows.STATUS_INVALID_PARAMETER
+		}
+		if attribute&windows.FILE_ATTRIBUTE_READONLY != 0 {
+			permissions := virtual.PermissionsRead
+			_, file := leaf.GetPair()
+			if file != nil {
+				permissions |= virtual.PermissionsExecute
+			}
+			newAttributes.SetPermissions(permissions)
+			*attributesMask |= virtual.AttributesMaskPermissions
+		}
+		if attribute&windows.FILE_ATTRIBUTE_DIRECTORY != 0 {
+			dir, _ := leaf.GetPair()
+			if dir == nil {
+				return windows.STATUS_NOT_A_DIRECTORY
+			}
+		}
+	}
+	return nil
+}
+
+func toWinFSPFileAttributes(attributes *virtual.Attributes) uint32 {
+	var fileAttributes uint32
+	switch attributes.GetFileType() {
+	case filesystem.FileTypeRegularFile:
+		fileAttributes |= windows.FILE_ATTRIBUTE_NORMAL
+	case filesystem.FileTypeDirectory:
+		fileAttributes |= windows.FILE_ATTRIBUTE_DIRECTORY
+	case filesystem.FileTypeSymlink:
+		fileAttributes |= windows.FILE_ATTRIBUTE_REPARSE_POINT
+	default:
+	}
+	if permissions, ok := attributes.GetPermissions(); ok && permissions&virtual.PermissionsWrite == 0 {
+		fileAttributes |= windows.FILE_ATTRIBUTE_READONLY
+	}
+	return fileAttributes
+}
+
+func toWinFSPFileInfo(attributes *virtual.Attributes, info *ffi.FSP_FSCTL_FILE_INFO) {
+	info.EaSize = 0
+	info.HardLinks = attributes.GetLinkCount()
+	info.IndexNumber = attributes.GetInodeNumber()
+	info.FileAttributes = toWinFSPFileAttributes(attributes)
+	info.ReparseTag = 0
+
+	if attributes.GetFileType() == filesystem.FileTypeSymlink {
+		info.ReparseTag = windows.IO_REPARSE_TAG_SYMLINK
+	}
+
+	if sizeBytes, ok := attributes.GetSizeBytes(); ok {
+		info.FileSize = sizeBytes
+		// Set allocation size (rounded up to 4KB boundaries like in go-winfsp)
+		info.AllocationSize = ((sizeBytes + 4095) / 4096) * 4096
+	}
+
+	info.ChangeTime = filetime.Timestamp(filesystem.DeterministicFileModificationTimestamp)
+	info.CreationTime = filetime.Timestamp(filesystem.DeterministicFileModificationTimestamp)
+	info.LastAccessTime = filetime.Timestamp(filesystem.DeterministicFileModificationTimestamp)
+	lastWriteTime, present := attributes.GetLastDataModificationTime()
+	if !present {
+		lastWriteTime = filesystem.DeterministicFileModificationTimestamp
+	}
+	info.LastWriteTime = filetime.Timestamp(lastWriteTime)
+}
+
+const (
+	fileAddFile         windows.ACCESS_MASK = 0x02
+	fileAddSubdirectory windows.ACCESS_MASK = 0x04
+	fileDeleteChild     windows.ACCESS_MASK = 0x40
+
+	ownerDefaultPermissions windows.ACCESS_MASK = windows.DELETE |
+		windows.WRITE_DAC |
+		windows.WRITE_OWNER |
+		windows.FILE_WRITE_ATTRIBUTES |
+		windows.FILE_WRITE_EA
+)
+
+func mapPermissionToAccessMask(mode virtual.Permissions, fileType filesystem.FileType) windows.ACCESS_MASK {
+	var result windows.ACCESS_MASK = windows.FILE_READ_ATTRIBUTES |
+		windows.FILE_READ_EA |
+		windows.READ_CONTROL |
+		windows.SYNCHRONIZE
+	if mode&virtual.PermissionsRead != 0 {
+		result |= windows.FILE_LIST_DIRECTORY |
+			windows.FILE_READ_DATA |
+			windows.FILE_TRAVERSE
+	}
+	if mode&virtual.PermissionsWrite != 0 {
+		result |= windows.FILE_APPEND_DATA |
+			windows.FILE_WRITE_ATTRIBUTES |
+			windows.FILE_WRITE_DATA |
+			windows.FILE_WRITE_EA
+		if fileType == filesystem.FileTypeDirectory {
+			result |= fileAddFile |
+				fileAddSubdirectory |
+				fileDeleteChild
+		}
+	}
+	if mode&virtual.PermissionsExecute != 0 {
+		result |= windows.FILE_EXECUTE |
+			windows.FILE_TRAVERSE
+	}
+	return result
+}
+
+// Calculates a security descriptor for the attributes by looking at the
+// permissions and owner/group IDs in the attributes.
+func toSecurityDescriptor(attributes *virtual.Attributes) (*windows.SECURITY_DESCRIPTOR, error) {
+	var err error
+
+	// Compute the owner, falling back to the current processes' user.
+	var ownerSid *windows.SID
+	if uid, ok := attributes.GetOwnerUserID(); ok {
+		ownerSid, err = ffi.PosixMapUidToSid(uid)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		ownerSid, _, err = getCurrentProcessUserAndGroup()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Get group SID.
+	var groupSid *windows.SID
+	if gid, ok := attributes.GetOwnerGroupID(); ok {
+		groupSid, err = ffi.PosixMapUidToSid(gid)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		_, groupSid, err = getCurrentProcessUserAndGroup()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	mode, ok := attributes.GetPermissions()
+	if !ok {
+		panic("Attributes do not contain mandatory permissions attribute")
+	}
+
+	everyoneSid, err := getEveryoneSid()
+	if err != nil {
+		return nil, err
+	}
+
+	permissions := mapPermissionToAccessMask(mode, attributes.GetFileType())
+	aclEntries := [2]windows.EXPLICIT_ACCESS{
+		// The owner has additional permissions to, for example, modify the
+		// permissions
+		{
+			AccessPermissions: permissions | ownerDefaultPermissions,
+			AccessMode:        windows.GRANT_ACCESS,
+			Inheritance:       windows.NO_INHERITANCE,
+			Trustee: windows.TRUSTEE{
+				TrusteeForm:  windows.TRUSTEE_IS_SID,
+				TrusteeValue: windows.TrusteeValueFromSID(ownerSid),
+			},
+		},
+		// Since the VFS has the same permissions for user/group/everyone,
+		// we can group most permissions under one entry.
+		{
+			AccessPermissions: permissions,
+			AccessMode:        windows.GRANT_ACCESS,
+			Inheritance:       windows.NO_INHERITANCE,
+			Trustee: windows.TRUSTEE{
+				TrusteeForm:  windows.TRUSTEE_IS_SID,
+				TrusteeValue: windows.TrusteeValueFromSID(everyoneSid),
+			},
+		},
+	}
+
+	// Build the security descriptor.
+	sd, err := windows.NewSecurityDescriptor()
+	if err != nil {
+		return nil, err
+	}
+	// Don't allow inheritance of security descriptors from parents.
+	if err := sd.SetControl(windows.SE_DACL_PROTECTED, windows.SE_DACL_PROTECTED); err != nil {
+		return nil, err
+	}
+	if err := sd.SetOwner(ownerSid, false); err != nil {
+		return nil, err
+	}
+	if err := sd.SetGroup(groupSid, false); err != nil {
+		return nil, err
+	}
+	dacl, err := windows.ACLFromEntries(aclEntries[:], nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := sd.SetDACL(dacl, true, false); err != nil {
+		return nil, err
+	}
+
+	return sd.ToSelfRelative()
+}
+
+// Sets the attributes of node, and stores the updated attributes in info.
+func setAndGetAttributes(ctx context.Context, newAttributesMask virtual.AttributesMask, node virtual.Node, newAttributes virtual.Attributes, info *ffi.FSP_FSCTL_FILE_INFO) error {
+	var attributesOut virtual.Attributes
+	if newAttributesMask != 0 {
+		status := node.VirtualSetAttributes(ctx, &newAttributes, AttributesMaskForWinFSPAttr, &attributesOut)
+		if status != virtual.StatusOK {
+			return toNTStatus(status)
+		}
+	} else {
+		node.VirtualGetAttributes(ctx, AttributesMaskForWinFSPAttr, &attributesOut)
+	}
+	toWinFSPFileInfo(&attributesOut, info)
+	return nil
+}
+
+type directoryResolver struct {
+	ctx     context.Context
+	current virtual.Directory
+}
+
+func (d *directoryResolver) OnDirectory(component path.Component) (path.GotDirectoryOrSymlink, error) {
+	var attributes virtual.Attributes
+	child, status := d.current.VirtualLookup(d.ctx, component, virtual.AttributesMaskFileType, &attributes)
+	if status != virtual.StatusOK {
+		return nil, toNTStatus(status)
+	}
+	d.current, _ = child.GetPair()
+	if d.current == nil {
+		return nil, windows.STATUS_NOT_A_DIRECTORY
+	}
+	return path.GotDirectory{
+		Child:        d,
+		IsReversible: false,
+	}, nil
+}
+
+func (d *directoryResolver) OnTerminal(name path.Component) (*path.GotSymlink, error) {
+	return path.OnTerminalViaOnDirectory(d, name)
+}
+
+func (d *directoryResolver) OnUp() (path.ComponentWalker, error) {
+	return nil, windows.STATUS_OBJECT_NAME_NOT_FOUND
+}
+
+func (d *directoryResolver) OnAbsolute() (path.ComponentWalker, error) {
+	return d, nil
+}
+
+func (d *directoryResolver) OnDriveLetter(drive rune) (path.ComponentWalker, error) {
+	return nil, windows.STATUS_OBJECT_NAME_NOT_FOUND
+}
+
+func (d *directoryResolver) OnRelative() (path.ComponentWalker, error) {
+	return nil, windows.STATUS_OBJECT_NAME_NOT_FOUND
+}
+
+func (d *directoryResolver) OnShare(server, share string) (path.ComponentWalker, error) {
+	return nil, windows.STATUS_OBJECT_NAME_NOT_FOUND
+}
+
+// resolveDirectory resolves a path from WinFSP into a virtual.Directory. It
+// is only designed to cope with directory paths from WinFSP, which are guaranteed
+// to start with \ and not contain any .. components.
+func (fs *FileSystem) resolveDirectory(ctx context.Context, name string) (virtual.Directory, error) {
+	w := directoryResolver{
+		current: fs.rootDirectory,
+		ctx:     ctx,
+	}
+	if err := path.Resolve(path.LocalFormat.NewParser(name), &w); err != nil {
+		return nil, err
+	}
+	return w.current, nil
+}
+
+func (fs *FileSystem) openOrCreateDir(ctx context.Context, parent virtual.Directory, leafName path.Component, disposition uint32, attributes *virtual.Attributes) (virtual.DirectoryChild, error) {
+	switch disposition {
+	case windows.FILE_OPEN, windows.FILE_OPEN_IF:
+		// Ty and open an existing directory
+		child, status := parent.VirtualLookup(ctx, leafName, AttributesMaskForWinFSPAttr, attributes)
+		if status == virtual.StatusOK {
+			if directory, _ := child.GetPair(); directory == nil {
+				if attributes.GetFileType() == filesystem.FileTypeSymlink {
+					// If it's a symlink then we have no way of checking
+					// whether the target is a directory or not, since the
+					// symlink might be to a file that is outside of the VFS.
+					// We therefore do not enforce that the file is a
+					// directory. This is like WinFSP's fuse implementation.
+					return child, nil
+				}
+				return virtual.DirectoryChild{}, windows.STATUS_NOT_A_DIRECTORY
+			}
+			return child, nil
+		}
+		// Fallthrough to creation.
+
+	case windows.FILE_CREATE:
+		// Fallthrough to creation.
+
+	default:
+		return virtual.DirectoryChild{}, windows.STATUS_INVALID_PARAMETER
+	}
+
+	// Create new directory.
+	childDir, _, status := parent.VirtualMkdir(leafName, AttributesMaskForWinFSPAttr, attributes)
+	if status != virtual.StatusOK {
+		return virtual.DirectoryChild{}, toNTStatus(status)
+	}
+	return virtual.DirectoryChild{}.FromDirectory(childDir), nil
+}
+
+// openOrCreateFileOrDir opens an existing file or directory, or creates a new file.
+func (fs *FileSystem) openOrCreateFileOrDir(ctx context.Context, parent virtual.Directory, leafName path.Component, disposition uint32, shareMask virtual.ShareMask, createPermissions virtual.Permissions, attributes *virtual.Attributes) (virtual.DirectoryChild, virtual.ShareMask, error) {
+	var createAttributes *virtual.Attributes
+	var existingOptions *virtual.OpenExistingOptions
+
+	switch disposition {
+	case windows.FILE_OPEN:
+		existingOptions = &virtual.OpenExistingOptions{}
+	case windows.FILE_CREATE:
+		createAttributes = &virtual.Attributes{}
+	case windows.FILE_OPEN_IF:
+		createAttributes = &virtual.Attributes{}
+		existingOptions = &virtual.OpenExistingOptions{}
+	case windows.FILE_OVERWRITE:
+		existingOptions = &virtual.OpenExistingOptions{Truncate: true}
+	case windows.FILE_OVERWRITE_IF:
+		createAttributes = &virtual.Attributes{}
+		existingOptions = &virtual.OpenExistingOptions{Truncate: true}
+	case windows.FILE_SUPERSEDE:
+		// We treat this like a standard truncate, which is not strictly
+		// speaking correct: Supersede really means "delete and recreate",
+		// which would mean throwing away some attributes. However, it's not
+		// uncommon to treat it like O_TRUNC; some SMB implementations do
+		// for example.
+		createAttributes = &virtual.Attributes{}
+		existingOptions = &virtual.OpenExistingOptions{Truncate: true}
+	default:
+		return virtual.DirectoryChild{}, 0, windows.STATUS_INVALID_PARAMETER
+	}
+
+	if createAttributes != nil && createPermissions != 0 {
+		createAttributes.SetPermissions(createPermissions)
+	}
+
+	var child virtual.DirectoryChild
+	leaf, _, _, status := parent.VirtualOpenChild(ctx, leafName, shareMask, createAttributes, existingOptions, AttributesMaskForWinFSPAttr, attributes)
+	switch status {
+	case virtual.StatusOK:
+		child = virtual.DirectoryChild{}.FromLeaf(leaf)
+	case virtual.StatusErrNoEnt, virtual.StatusErrIsDir, virtual.StatusErrSymlink:
+		// We were asked to open a file, but the target is a directory or
+		// symlink so use VirtualLookup instead.
+		//
+		// We also handle ErrNoEnt in the same way: some VFS implementations
+		// (e.g. bonanza) return ErrNoEnt when VirtualOpenChild is called even
+		// if a directory of the same name exists.
+		child, status = parent.VirtualLookup(ctx, leafName, AttributesMaskForWinFSPAttr, attributes)
+		// In this case, the file is not actually open so reset the shareMask.
+		shareMask = 0
+	}
+	if status != virtual.StatusOK {
+		return virtual.DirectoryChild{}, 0, toNTStatus(status)
+	}
+	return child, shareMask, nil
+}
+
+func (fs *FileSystem) createHandle(ctx context.Context, name string, createOptions, grantedAccess uint32, createPermissions virtual.Permissions, info *ffi.FSP_FSCTL_FILE_INFO) (uintptr, error) {
+	if createOptions&unsupportedCreateOptions != 0 {
+		return 0, windows.STATUS_INVALID_PARAMETER
+	}
+	if createOptions&fileAndDirectoryFlag == fileAndDirectoryFlag {
+		// Can't be both
+		return 0, windows.STATUS_INVALID_PARAMETER
+	}
+	disposition := (createOptions >> 24) & 0x0ff
+
+	var attributes virtual.Attributes
+	var parent virtual.Directory
+	var component path.Component
+	var node virtual.DirectoryChild
+	var shareMask virtual.ShareMask
+	parentName, leafName, err := parsePath(name)
+	if err != nil {
+		return 0, err
+	}
+	if leafName == nil {
+		// This is the root: this is a bit special
+		if createOptions&windows.FILE_NON_DIRECTORY_FILE != 0 {
+			return 0, windows.STATUS_FILE_IS_A_DIRECTORY
+		}
+
+		switch disposition {
+		case windows.FILE_OPEN, windows.FILE_OPEN_IF:
+			node = virtual.DirectoryChild{}.FromDirectory(fs.rootDirectory)
+			node.GetNode().VirtualGetAttributes(ctx, AttributesMaskForWinFSPAttr, &attributes)
+
+		case windows.FILE_CREATE:
+			return 0, windows.STATUS_OBJECT_NAME_COLLISION
+		default:
+			return 0, windows.STATUS_INVALID_PARAMETER
+		}
+	} else {
+		parent, err = fs.resolveDirectory(ctx, parentName)
+		if err != nil {
+			return 0, err
+		}
+
+		// Handle dispositions through the appropriate function based on whether it's a directory or file
+		if createOptions&windows.FILE_DIRECTORY_FILE != 0 {
+			node, err = fs.openOrCreateDir(ctx, parent, *leafName, disposition, &attributes)
+		} else {
+			node, shareMask, err = fs.openOrCreateFileOrDir(ctx, parent, *leafName, disposition, toShareMask(grantedAccess), createPermissions, &attributes)
+		}
+		if err != nil {
+			return 0, err
+		}
+		component = *leafName
+	}
+
+	handle := fs.openFiles.createHandle(parent, component, node, shareMask)
+	toWinFSPFileInfo(&attributes, info)
+	return handle, nil
+}
+
+func (fs *FileSystem) createContext() (context.Context, error) {
+	// Currently we just return a default context, but this could be extended
+	// in the future to perform some authentication of requests.
+	return context.Background(), nil
+}
+
+func (fs *FileSystem) Create(ref *ffi.FileSystemRef, name string, createOptions, grantedAccess, fileAttributes uint32, securityDescriptor *windows.SECURITY_DESCRIPTOR, allocationSize uint64, info *ffi.FSP_FSCTL_FILE_INFO) (uintptr, error) {
+	ctx, err := fs.createContext()
+	if err != nil {
+		return 0, err
+	}
+	// We need to set the default permissions for this file. We don't have
+	// much to set this based on as Windows doesn't have an equivalent of
+	// umask; instead in Windows files normally inherit their permissions
+	// from the parent directory. However this doesn't work well with the VFS
+	// as it stores permissions per node and nodes always have permissions
+	// attached.
+	createPermissions := virtual.PermissionsExecute | virtual.PermissionsRead
+	if fileAttributes&windows.FILE_ATTRIBUTE_READONLY == 0 {
+		createPermissions |= virtual.PermissionsWrite
+	}
+	return fs.createHandle(ctx, name, createOptions, grantedAccess, createPermissions, info)
+}
+
+func (fs *FileSystem) Open(ref *ffi.FileSystemRef, name string, createOptions, grantedAccess uint32, info *ffi.FSP_FSCTL_FILE_INFO) (uintptr, error) {
+	ctx, err := fs.createContext()
+	if err != nil {
+		return 0, err
+	}
+	return fs.createHandle(ctx, name, createOptions, grantedAccess, 0, info)
+}
+
+func (fs *FileSystem) Close(ref *ffi.FileSystemRef, handle uintptr) {
+	node, err := fs.openFiles.removeHandle(handle)
+	if err != nil {
+		return
+	}
+	_, leaf := node.node.GetPair()
+	if leaf != nil && node.shareMask != 0 {
+		leaf.VirtualClose(node.shareMask)
+	}
+}
+
+// Writes directory entries into a buffer in the WinFSP format.
+type dirBufferWriter struct {
+	buffer       []byte
+	cookieOffset uint64
+	exhausted    bool
+	writtenBytes int
+}
+
+// Adds a directory to the buffer, returning false if the buffer has been
+// exhausted.
+func (dc *dirBufferWriter) append(name string, nextCookie uint64, info *ffi.FSP_FSCTL_FILE_INFO) bool {
+	written := ffi.FileSystemAddDirInfo(name, nextCookie, info, dc.buffer[dc.writtenBytes:])
+	if written == 0 {
+		// The buffer is too small.
+		dc.exhausted = true
+		return false
+	}
+	dc.writtenBytes += written
+	return true
+}
+
+func (dc *dirBufferWriter) ReportEntry(nextCookie uint64, name path.Component, child virtual.DirectoryChild, attributes *virtual.Attributes) bool {
+	var info ffi.FSP_FSCTL_FILE_INFO
+	toWinFSPFileInfo(attributes, &info)
+	return dc.append(name.String(), nextCookie+dc.cookieOffset, &info)
+}
+
+func (fs *FileSystem) ReadDirectoryOffset(ref *ffi.FileSystemRef, handle uintptr, pattern *uint16, offset uint64, buffer []byte) (int, error) {
+	ctx, err := fs.createContext()
+	if err != nil {
+		return 0, err
+	}
+
+	directory, err := fs.openFiles.nodeForDirectoryHandle(handle)
+	if err != nil {
+		return 0, err
+	}
+
+	dc := dirBufferWriter{
+		buffer: buffer,
+	}
+
+	var readDirCookie uint64
+	if directory == fs.rootDirectory {
+		readDirCookie = offset
+	} else {
+		// For everything aside from the root we have to include "." and ".."
+		// entries. Thus we offset the VFS cookies by 2.
+		dc.cookieOffset = 2
+		if offset >= dc.cookieOffset {
+			readDirCookie = offset - dc.cookieOffset
+		}
+
+		if offset <= 0 {
+			if !dc.append(".", 1, &ffi.FSP_FSCTL_FILE_INFO{
+				FileAttributes: windows.FILE_ATTRIBUTE_DIRECTORY,
+			}) {
+				return dc.writtenBytes, nil
+			}
+		}
+		if offset <= 1 {
+			if !dc.append("..", 2, &ffi.FSP_FSCTL_FILE_INFO{
+				FileAttributes: windows.FILE_ATTRIBUTE_DIRECTORY,
+			}) {
+				return dc.writtenBytes, nil
+			}
+		}
+	}
+
+	status := directory.VirtualReadDir(ctx, readDirCookie, AttributesMaskForWinFSPAttr, &dc)
+	if status != virtual.StatusOK {
+		return 0, toNTStatus(status)
+	}
+	if !dc.exhausted {
+		// Must have reached the end: add the null entry.
+		dc.append("", 0, nil)
+	}
+	return dc.writtenBytes, nil
+}
+
+func (fs *FileSystem) GetFileInfo(ref *ffi.FileSystemRef, handle uintptr, info *ffi.FSP_FSCTL_FILE_INFO) error {
+	ctx, err := fs.createContext()
+	if err != nil {
+		return err
+	}
+	node, err := fs.openFiles.nodeForHandle(handle)
+	if err != nil {
+		return err
+	}
+	var attributes virtual.Attributes
+	node.GetNode().VirtualGetAttributes(ctx, AttributesMaskForWinFSPAttr, &attributes)
+	toWinFSPFileInfo(&attributes, info)
+	return nil
+}
+
+func (fs *FileSystem) GetVolumeInfo(ref *ffi.FileSystemRef, info *ffi.FSP_FSCTL_VOLUME_INFO) error {
+	// Sizes are 0 as the VFS does not maintain them.
+	info.FreeSize = 0
+	info.TotalSize = 0
+	info.VolumeLabelLength = 2 * uint16(copy(info.VolumeLabel[:], fs.label[:]))
+	return nil
+}
+
+func (fs *FileSystem) Overwrite(ref *ffi.FileSystemRef, handle uintptr, winfspAttributes uint32, replaceAttributes bool, allocationSize uint64, info *ffi.FSP_FSCTL_FILE_INFO) error {
+	ctx, err := fs.createContext()
+	if err != nil {
+		return err
+	}
+
+	openNode, err := fs.openFiles.nodeForHandle(handle)
+	if err != nil {
+		return err
+	}
+	_, file := openNode.GetPair()
+	if file == nil {
+		return windows.STATUS_FILE_IS_A_DIRECTORY
+	}
+
+	var newAttributes virtual.Attributes
+	var newAttributesMask virtual.AttributesMask
+	if !replaceAttributes {
+		// Then initialise based on the current attributes.
+		file.VirtualGetAttributes(ctx, AttributesMaskForWinFSPAttr, &newAttributes)
+	}
+
+	// Add additional attributes
+	toVirtualAttributes(openNode, winfspAttributes, &newAttributes, &newAttributesMask)
+	newAttributesMask |= virtual.AttributesMaskSizeBytes
+	newAttributes.SetSizeBytes(0)
+
+	return setAndGetAttributes(ctx, newAttributesMask, file, newAttributes, info)
+}
+
+func (fs *FileSystem) Read(ref *ffi.FileSystemRef, handle uintptr, buffer []byte, offset uint64) (int, error) {
+	_, err := fs.createContext()
+	if err != nil {
+		return 0, err
+	}
+
+	file, err := fs.openFiles.nodeForLeafHandle(handle)
+	if err != nil {
+		return 0, err
+	}
+	read, eof, status := file.VirtualRead(buffer, offset)
+	if status != virtual.StatusOK {
+		return read, toNTStatus(status)
+	}
+	if read == 0 && eof {
+		// Must have tried to read at the end of the file
+		return 0, windows.STATUS_END_OF_FILE
+	}
+	return read, nil
+}
+
+func (fs *FileSystem) Write(ref *ffi.FileSystemRef, handle uintptr, buf []byte, offset uint64, writeToEndOfFile, constrainedIo bool, info *ffi.FSP_FSCTL_FILE_INFO) (int, error) {
+	ctx, err := fs.createContext()
+	if err != nil {
+		return 0, err
+	}
+
+	file, err := fs.openFiles.nodeForLeafHandle(handle)
+	if err != nil {
+		return 0, err
+	}
+
+	if constrainedIo || writeToEndOfFile {
+		var attributes virtual.Attributes
+		file.VirtualGetAttributes(ctx, virtual.AttributesMaskSizeBytes, &attributes)
+		sizeBytes, ok := attributes.GetSizeBytes()
+		if !ok {
+			return 0, windows.STATUS_INVALID_PARAMETER
+		}
+
+		if constrainedIo {
+			// Then constrain the buffer to the file size.
+			if offset >= sizeBytes {
+				return 0, nil
+			}
+			if offset+uint64(len(buf)) > sizeBytes {
+				buf = buf[:sizeBytes-offset]
+			}
+		} else if writeToEndOfFile {
+			offset = sizeBytes
+		}
+	}
+
+	written, status := file.VirtualWrite(buf, offset)
+	if status != virtual.StatusOK {
+		return written, toNTStatus(status)
+	}
+
+	// Update file info with new attributes after write
+	var attributes virtual.Attributes
+	file.VirtualGetAttributes(ctx, AttributesMaskForWinFSPAttr, &attributes)
+	toWinFSPFileInfo(&attributes, info)
+
+	return written, nil
+}
+
+func (fs *FileSystem) Flush(ref *ffi.FileSystemRef, handle uintptr, info *ffi.FSP_FSCTL_FILE_INFO) error {
+	// Like the other VFS frontends (e.g. FUSE) we don't actually implement flush.
+	ctx, err := fs.createContext()
+	if err != nil {
+		return err
+	}
+
+	// Check if it's a volume flush (file handle is 0)
+	if handle == 0 {
+		return nil
+	}
+
+	openNode, err := fs.openFiles.nodeForHandle(handle)
+	if err != nil {
+		return err
+	}
+	var attributes virtual.Attributes
+	openNode.GetNode().VirtualGetAttributes(ctx, AttributesMaskForWinFSPAttr, &attributes)
+	toWinFSPFileInfo(&attributes, info)
+	return nil
+}
+
+func (fs *FileSystem) SetBasicInfo(ref *ffi.FileSystemRef, handle uintptr, flags ffi.SetBasicInfoFlags, attribute uint32, creationTime, lastAccessTime, lastWriteTime, changeTime uint64, info *ffi.FSP_FSCTL_FILE_INFO) error {
+	ctx, err := fs.createContext()
+	if err != nil {
+		return err
+	}
+
+	openNode, err := fs.openFiles.nodeForHandle(handle)
+	if err != nil {
+		return err
+	}
+	node := openNode.GetNode()
+
+	var newAttributes virtual.Attributes
+	attributesMask := virtual.AttributesMask(0)
+
+	toVirtualAttributes(openNode, attribute, &newAttributes, &attributesMask)
+
+	if flags&ffi.SetBasicInfoLastWriteTime != 0 {
+		attributesMask |= virtual.AttributesMaskLastDataModificationTime
+		newAttributes.SetLastDataModificationTime(filetimeToTime(lastWriteTime))
+	}
+
+	return setAndGetAttributes(ctx, attributesMask, node, newAttributes, info)
+}
+
+func (fs *FileSystem) SetVolumeLabel(ref *ffi.FileSystemRef, volumeLabel string, info *ffi.FSP_FSCTL_VOLUME_INFO) error {
+	utf16, err := windows.UTF16FromString(volumeLabel)
+	if err != nil {
+		return err
+	}
+	fs.label = utf16
+	return nil
+}
+
+func (fs *FileSystem) SetFileSize(ref *ffi.FileSystemRef, handle uintptr, newSize uint64, setAllocationSize bool, info *ffi.FSP_FSCTL_FILE_INFO) error {
+	ctx, err := fs.createContext()
+	if err != nil {
+		return err
+	}
+
+	file, err := fs.openFiles.nodeForLeafHandle(handle)
+	if err != nil {
+		return err
+	}
+
+	var setSize bool
+	if setAllocationSize {
+		// We need to ensure that file size is less than the allocation size,
+		// so might still need to do truncation here even though we don't
+		// maintain allocation size in the VFS.
+		var attributes virtual.Attributes
+		file.VirtualGetAttributes(ctx, virtual.AttributesMaskSizeBytes, &attributes)
+		if sizeBytes, ok := attributes.GetSizeBytes(); ok && sizeBytes > newSize {
+			// Truncate the file to the new size
+			setSize = true
+		}
+	} else {
+		setSize = true
+	}
+
+	var newAttributes virtual.Attributes
+	var attributesMask virtual.AttributesMask
+	if setSize {
+		newAttributes.SetSizeBytes(newSize)
+		attributesMask |= virtual.AttributesMaskSizeBytes
+	}
+	return setAndGetAttributes(ctx, attributesMask, file, newAttributes, info)
+}
+
+func (fs *FileSystem) CanDelete(ref *ffi.FileSystemRef, handle uintptr, name string) error {
+	ctx, err := fs.createContext()
+	if err != nil {
+		return err
+	}
+
+	openNode, err := fs.openFiles.nodeForHandle(handle)
+	if err != nil {
+		return err
+	}
+
+	directory, _ := openNode.GetPair()
+	if directory == nil {
+		// Leaves can always be deleted.
+		return nil
+	}
+
+	// For directories, check if they are empty.
+	isEmpty := true
+	status := directory.VirtualReadDir(ctx, 0, 0, &emptyDirectoryChecker{&isEmpty})
+	if status != virtual.StatusOK {
+		return toNTStatus(status)
+	}
+	if !isEmpty {
+		return windows.STATUS_DIRECTORY_NOT_EMPTY
+	}
+	return nil
+}
+
+type emptyDirectoryChecker struct {
+	isEmpty *bool
+}
+
+func (e *emptyDirectoryChecker) ReportEntry(nextCookie uint64, name path.Component, child virtual.DirectoryChild, attributes *virtual.Attributes) bool {
+	*e.isEmpty = false
+	// Stop iterating.
+	return false
+}
+
+func (fs *FileSystem) Cleanup(ref *ffi.FileSystemRef, handle uintptr, name string, cleanupFlags uint32) {
+	ctx, err := fs.createContext()
+	if err != nil {
+		return
+	}
+
+	openNode, err := fs.openFiles.trackedNodeForHandle(handle)
+	if err != nil {
+		return
+	}
+
+	var attributes virtual.Attributes
+	var attributesMask virtual.AttributesMask
+
+	if cleanupFlags&ffi.FspCleanupSetLastWriteTime != 0 {
+		attributes.SetLastDataModificationTime(time.Now())
+		attributesMask |= virtual.AttributesMaskLastDataModificationTime
+	}
+
+	if attributesMask != 0 {
+		var outAttributes virtual.Attributes
+		openNode.node.GetNode().VirtualSetAttributes(ctx, &attributes, attributesMask, &outAttributes)
+	}
+
+	// Check if we should delete the file.
+	if cleanupFlags&ffi.FspCleanupDelete != 0 && openNode.parent != nil {
+		directory, _ := openNode.node.GetPair()
+		isDirectory := directory != nil
+		_, fileName, err := parsePath(name)
+		if err == nil && fileName != nil {
+			openNode.parent.VirtualRemove(*fileName, isDirectory, !isDirectory)
+		}
+	}
+}
+
+func (fs *FileSystem) GetDirInfoByName(ref *ffi.FileSystemRef, parentHandle uintptr, name string, dirInfo *ffi.FSP_FSCTL_DIR_INFO) error {
+	ctx, err := fs.createContext()
+	if err != nil {
+		return err
+	}
+
+	// Get the parent directory
+	parentDirectory, err := fs.openFiles.nodeForDirectoryHandle(parentHandle)
+	if err != nil {
+		return err
+	}
+
+	var attributes virtual.Attributes
+	_, status := parentDirectory.VirtualLookup(ctx, path.MustNewComponent(name), AttributesMaskForWinFSPAttr, &attributes)
+	if status != virtual.StatusOK {
+		return toNTStatus(status)
+	}
+
+	toWinFSPFileInfo(&attributes, &dirInfo.FileInfo)
+
+	return nil
+}
+
+func (fs *FileSystem) GetSecurity(ref *ffi.FileSystemRef, handle uintptr) (*windows.SECURITY_DESCRIPTOR, error) {
+	ctx, err := fs.createContext()
+	if err != nil {
+		return nil, err
+	}
+	node, err := fs.openFiles.nodeForHandle(handle)
+	if err != nil {
+		return nil, err
+	}
+	var attributes virtual.Attributes
+	node.GetNode().VirtualGetAttributes(ctx, AttributesMaskForWinFSPAttr, &attributes)
+	return toSecurityDescriptor(&attributes)
+}
+
+func (fs *FileSystem) containsReparsePoint(ref *ffi.FileSystemRef, fileName string) bool {
+	found, _, err := ffi.FileSystemFindReparsePoint(ref, fileName)
+	if found && err == nil {
+		return found
+	}
+	return false
+}
+
+func (fs *FileSystem) GetSecurityByName(ref *ffi.FileSystemRef, name string, flags ffi.GetSecurityByNameFlags) (uint32, *windows.SECURITY_DESCRIPTOR, error) {
+	ctx, err := fs.createContext()
+	if err != nil {
+		return 0, nil, err
+	}
+
+	var attributes virtual.Attributes
+	parentName, leafName, err := parsePath(name)
+	if err != nil {
+		return 0, nil, err
+	}
+	if leafName == nil {
+		fs.rootDirectory.VirtualGetAttributes(ctx, AttributesMaskForWinFSPAttr, &attributes)
+	} else {
+		parent, err := fs.resolveDirectory(ctx, parentName)
+		if err != nil {
+			if fs.containsReparsePoint(ref, name) {
+				return 0, nil, windows.STATUS_REPARSE
+			}
+			return 0, nil, err
+		}
+		_, status := parent.VirtualLookup(ctx, *leafName, AttributesMaskForWinFSPAttr, &attributes)
+		if status != virtual.StatusOK {
+			if fs.containsReparsePoint(ref, name) {
+				return 0, nil, windows.STATUS_REPARSE
+			}
+			return 0, nil, toNTStatus(status)
+		}
+	}
+
+	if flags == ffi.GetExistenceOnly {
+		return 0, nil, nil
+	}
+
+	var sd *windows.SECURITY_DESCRIPTOR
+	if (flags & ffi.GetSecurityByName) != 0 {
+		sd, err = toSecurityDescriptor(&attributes)
+		if err != nil {
+			return 0, nil, err
+		}
+	}
+	return toWinFSPFileAttributes(&attributes), sd, nil
+}
+
+// Splits the last component from the rest of the path.
+func parsePath(name string) (parentName string, leafName *path.Component, err error) {
+	if name == "\\" {
+		return "\\", nil, nil
+	}
+	// Windows allows both forward and backward slashes:
+	// https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats
+	// Most of the time these are normalised to \ before reaching us, but
+	// it seems this is not true when we are handling reparse points.
+	lastSeparator := strings.LastIndexAny(name, "\\/")
+	if lastSeparator < 0 {
+		return "", nil, windows.STATUS_INVALID_PARAMETER
+	}
+	component, ok := path.NewComponent(name[lastSeparator+1:])
+	if !ok {
+		return "", nil, windows.STATUS_INVALID_PARAMETER
+	}
+	return name[:lastSeparator+1], &component, nil
+}
+
+func (fs *FileSystem) Rename(ref *ffi.FileSystemRef, handle uintptr, source, target string, replaceIfExist bool) error {
+	ctx, err := fs.createContext()
+	if err != nil {
+		return err
+	}
+
+	openNode, err := fs.openFiles.trackedNodeForHandle(handle)
+	if err != nil {
+		return err
+	}
+	if openNode.parent == nil {
+		return windows.STATUS_INVALID_PARAMETER
+	}
+
+	_, sourceLeafName, err := parsePath(source)
+	if err != nil {
+		return err
+	}
+	if sourceLeafName == nil {
+		return windows.STATUS_INVALID_PARAMETER
+	}
+	targetParentName, targetLeafName, err := parsePath(target)
+	if err != nil {
+		return err
+	}
+	if targetLeafName == nil {
+		return windows.STATUS_INVALID_PARAMETER
+	}
+	targetParent, err := fs.resolveDirectory(ctx, targetParentName)
+	if err != nil {
+		return err
+	}
+
+	// Check if target exists and handle replaceIfExist.
+	var attributes virtual.Attributes
+	if existingNode, status := targetParent.VirtualLookup(ctx, *targetLeafName, virtual.AttributesMaskFileType, &attributes); status == virtual.StatusOK {
+		if existingNode == openNode.node {
+			// Ok
+		} else {
+			if attributes.GetFileType() == filesystem.FileTypeDirectory {
+				// Windows never allows renames over an existing directory.
+				return windows.STATUS_ACCESS_DENIED
+			}
+			if !replaceIfExist {
+				return windows.STATUS_OBJECT_NAME_COLLISION
+			}
+		}
+	}
+
+	// Perform the rename operation
+	if _, _, status := openNode.parent.VirtualRename(*sourceLeafName, targetParent, *targetLeafName); status != virtual.StatusOK {
+		return toNTStatus(status)
+	}
+	return nil
+}
+
+func (fs *FileSystem) SetSecurity(ref *ffi.FileSystemRef, handle uintptr, info windows.SECURITY_INFORMATION, modificationDesc *windows.SECURITY_DESCRIPTOR) error {
+	ctx, err := fs.createContext()
+	if err != nil {
+		return err
+	}
+
+	openNode, err := fs.openFiles.nodeForHandle(handle)
+	if err != nil {
+		return err
+	}
+
+	var attributes virtual.Attributes
+	openNode.GetNode().VirtualGetAttributes(ctx, AttributesMaskForWinFSPAttr, &attributes)
+
+	currentSd, err := toSecurityDescriptor(&attributes)
+	if err != nil {
+		return err
+	}
+	newSd, err := ffi.SetSecurityDescriptor(currentSd, info, modificationDesc)
+	if err != nil {
+		return err
+	}
+	defer ffi.DeleteSecurityDescriptor(newSd)
+
+	uid, gid, mode, err := ffi.PosixMapSecurityDescriptorToPermissions(newSd)
+	if err != nil {
+		return err
+	}
+
+	attributes.SetOwnerGroupID(gid)
+	attributes.SetOwnerUserID(uid)
+	attributes.SetPermissions(virtual.NewPermissionsFromMode(mode))
+	var outAttributes virtual.Attributes
+	openNode.GetNode().VirtualSetAttributes(ctx,
+		&attributes,
+		virtual.AttributesMaskOwnerGroupID|virtual.AttributesMaskOwnerUserID|virtual.AttributesMaskPermissions,
+		&outAttributes)
+
+	return nil
+}
+
+func (fs *FileSystem) DeleteReparsePoint(ref *ffi.FileSystemRef, file uintptr, name string, buffer []byte) error {
+	// We can't support this: we can only support deleting the file, not
+	// deleting the symlink and thus converting it into a regular file.
+	// Thus we do exactly what the WinFSP fuse plugin does.
+	return windows.STATUS_ACCESS_DENIED
+}
+
+// FillSymlinkReparseBuffer populates buffer with a
+// windowsext.REPARSE_DATA_BUFFER for a symlink that points to target with
+// the passed flags. It returns the number of bytes written to the buffer.
+func FillSymlinkReparseBuffer(target string, flags uint32, buffer []byte) (int, error) {
+	targetUTF16, err := windows.UTF16FromString(string(target))
+	if err != nil {
+		return 0, err
+	}
+
+	// utf-16 encoded so 2 bytes per character; no null terminator needed.
+	targetUTF16Len := len(targetUTF16) - 1
+	targetUTF16Bytes := targetUTF16Len * 2
+	symbolicLinkReparseSize := int(unsafe.Sizeof(windowsext.SymbolicLinkReparseBuffer{})) -
+		// Exclude the PathBuffer member.
+		2 +
+		// Two copies of the target path.
+		targetUTF16Bytes*2
+	requiredSize := int(unsafe.Sizeof(windowsext.REPARSE_DATA_BUFFER_HEADER{})) + symbolicLinkReparseSize
+	if len(buffer) < requiredSize {
+		return 0, windows.STATUS_BUFFER_TOO_SMALL
+	}
+
+	rdb := (*windowsext.REPARSE_DATA_BUFFER)(unsafe.Pointer(&buffer[0]))
+	rdb.ReparseTag = windows.IO_REPARSE_TAG_SYMLINK
+	rdb.ReparseDataLength = uint16(symbolicLinkReparseSize)
+	rdb.Reserved = 0
+
+	slrb := (*windowsext.SymbolicLinkReparseBuffer)(unsafe.Pointer(&rdb.DUMMYUNIONNAME))
+	slrb.Flags = flags
+	slrb.SubstituteNameOffset = 0
+	slrb.SubstituteNameLength = uint16(targetUTF16Bytes)
+	slrb.PrintNameOffset = uint16(targetUTF16Bytes)
+	slrb.PrintNameLength = uint16(targetUTF16Bytes)
+
+	pathBuffer := unsafe.Slice(&slrb.PathBuffer[0], 2*targetUTF16Bytes)
+	copy(pathBuffer[0:targetUTF16Len], targetUTF16)
+	copy(pathBuffer[targetUTF16Len:targetUTF16Len*2], targetUTF16)
+
+	return requiredSize, nil
+}
+
+type relativePathChecker struct {
+	isRelative bool
+}
+
+func (d *relativePathChecker) OnAbsolute() (path.ComponentWalker, error) {
+	// This counts as relative as it's interpreted as relative to the
+	// current drive.
+	d.isRelative = true
+	return path.VoidComponentWalker, nil
+}
+
+func (d *relativePathChecker) OnDriveLetter(drive rune) (path.ComponentWalker, error) {
+	return path.VoidComponentWalker, nil
+}
+
+func (d *relativePathChecker) OnRelative() (path.ComponentWalker, error) {
+	d.isRelative = true
+	return path.VoidComponentWalker, nil
+}
+
+func (d *relativePathChecker) OnShare(server, share string) (path.ComponentWalker, error) {
+	return path.VoidComponentWalker, nil
+}
+
+func getReparsePointForLeaf(ctx context.Context, leaf virtual.Leaf, buffer []byte) (int, error) {
+	target, status := leaf.VirtualReadlink(ctx)
+	if status != virtual.StatusOK {
+		return 0, toNTStatus(status)
+	}
+	if buffer == nil {
+		// Then we were just interested in knowing if this was a reparse point.
+		return 0, nil
+	}
+
+	// Parse the path to determine if it's absolute
+	w := relativePathChecker{}
+	if err := path.Resolve(path.LocalFormat.NewParser(string(target)), &w); err != nil {
+		return 0, err
+	}
+	var flags int
+	if w.isRelative {
+		flags = windowsext.SYMLINK_FLAG_RELATIVE
+	}
+
+	return FillSymlinkReparseBuffer(string(target), uint32(flags), buffer)
+}
+
+func (fs *FileSystem) GetReparsePoint(ref *ffi.FileSystemRef, file uintptr, name string, buffer []byte) (int, error) {
+	ctx, err := fs.createContext()
+	if err != nil {
+		return 0, err
+	}
+	leaf, err := fs.openFiles.nodeForLeafHandle(file)
+	if err != nil {
+		return 0, err
+	}
+	return getReparsePointForLeaf(ctx, leaf, buffer)
+}
+
+func (fs *FileSystem) GetReparsePointByName(ref *ffi.FileSystemRef, name string, isDirectory bool, buffer []byte) (int, error) {
+	ctx, err := fs.createContext()
+	if err != nil {
+		return 0, err
+	}
+	parentName, leafName, err := parsePath(name)
+	if err != nil {
+		return 0, err
+	}
+	if leafName == nil {
+		return 0, windows.STATUS_NOT_A_REPARSE_POINT
+	}
+	parent, err := fs.resolveDirectory(ctx, parentName)
+	if err != nil {
+		return 0, err
+	}
+	var attributes virtual.Attributes
+	node, status := parent.VirtualLookup(ctx, *leafName, AttributesMaskForWinFSPAttr, &attributes)
+	if status != virtual.StatusOK {
+		return 0, toNTStatus(status)
+	}
+	if attributes.GetFileType() != filesystem.FileTypeSymlink {
+		return 0, windows.STATUS_NOT_A_REPARSE_POINT
+	}
+	_, leaf := node.GetPair()
+	if leaf == nil {
+		return 0, windows.STATUS_NOT_A_REPARSE_POINT
+	}
+	return getReparsePointForLeaf(ctx, leaf, buffer)
+}
+
+func (fs *FileSystem) SetReparsePoint(ref *ffi.FileSystemRef, handle uintptr, name string, buffer []byte) error {
+	ctx, err := fs.createContext()
+	if err != nil {
+		return err
+	}
+
+	node, err := fs.openFiles.trackedNodeForHandle(handle)
+	if err != nil {
+		return windows.STATUS_INVALID_HANDLE
+	}
+	if node.parent == nil {
+		// This is the root folder. We can't set a reparse point for this.
+		return windows.STATUS_INVALID_PARAMETER
+	}
+
+	if len(buffer) < int(unsafe.Sizeof(windowsext.REPARSE_DATA_BUFFER{})) {
+		return windows.STATUS_INVALID_PARAMETER
+	}
+	reparseBuffer := (*windowsext.REPARSE_DATA_BUFFER)(unsafe.Pointer(&buffer[0]))
+
+	switch reparseBuffer.ReparseTag {
+	case windows.IO_REPARSE_TAG_SYMLINK:
+		// Handle symbolic link reparse point
+		if reparseBuffer.ReparseDataLength < uint16(unsafe.Sizeof(windowsext.SymbolicLinkReparseBuffer{})) {
+			return windows.STATUS_INVALID_PARAMETER
+		}
+		symbolicLinkBuffer := (*windowsext.SymbolicLinkReparseBuffer)(unsafe.Pointer(&reparseBuffer.DUMMYUNIONNAME))
+		targetPath := symbolicLinkBuffer.Path()
+		if _, s := node.parent.VirtualRemove(node.name, true, true); s != virtual.StatusOK {
+			return toNTStatus(s)
+		}
+		var outAttributes virtual.Attributes
+		if _, _, s := node.parent.VirtualSymlink(ctx, []byte(targetPath), node.name, virtual.AttributesMaskFileType, &outAttributes); s != virtual.StatusOK {
+			return toNTStatus(s)
+		}
+
+		return nil
+
+	default:
+		return windows.STATUS_IO_REPARSE_TAG_MISMATCH
+	}
+}
+
+// Check we implement the relevant interfaces as go-winfsp uses which
+// interfaces we implement to determine capabilities.
+var (
+	_ ffi.BehaviourBase                  = (*FileSystem)(nil)
+	_ ffi.BehaviourCanDelete             = (*FileSystem)(nil)
+	_ ffi.BehaviourCleanup               = (*FileSystem)(nil)
+	_ ffi.BehaviourCreate                = (*FileSystem)(nil)
+	_ ffi.BehaviourDeleteReparsePoint    = (*FileSystem)(nil)
+	_ ffi.BehaviourFlush                 = (*FileSystem)(nil)
+	_ ffi.BehaviourGetDirInfoByName      = (*FileSystem)(nil)
+	_ ffi.BehaviourGetFileInfo           = (*FileSystem)(nil)
+	_ ffi.BehaviourGetReparsePoint       = (*FileSystem)(nil)
+	_ ffi.BehaviourGetReparsePointByName = (*FileSystem)(nil)
+	_ ffi.BehaviourGetSecurity           = (*FileSystem)(nil)
+	_ ffi.BehaviourGetSecurityByName     = (*FileSystem)(nil)
+	_ ffi.BehaviourGetVolumeInfo         = (*FileSystem)(nil)
+	_ ffi.BehaviourOverwrite             = (*FileSystem)(nil)
+	_ ffi.BehaviourRead                  = (*FileSystem)(nil)
+	_ ffi.BehaviourReadDirectoryOffset   = (*FileSystem)(nil)
+	_ ffi.BehaviourRename                = (*FileSystem)(nil)
+	_ ffi.BehaviourSetBasicInfo          = (*FileSystem)(nil)
+	_ ffi.BehaviourSetFileSize           = (*FileSystem)(nil)
+	_ ffi.BehaviourSetReparsePoint       = (*FileSystem)(nil)
+	_ ffi.BehaviourSetSecurity           = (*FileSystem)(nil)
+	_ ffi.BehaviourSetVolumeLabel        = (*FileSystem)(nil)
+	_ ffi.BehaviourWrite                 = (*FileSystem)(nil)
+)

--- a/pkg/filesystem/virtual/winfsp/file_system_integration_test.go
+++ b/pkg/filesystem/virtual/winfsp/file_system_integration_test.go
@@ -1,0 +1,494 @@
+//go:build windows
+// +build windows
+
+package winfsp_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	ffi "github.com/aegistudio/go-winfsp"
+	"github.com/bazelbuild/rules_go/go/runfiles"
+	"github.com/buildbarn/bb-remote-execution/pkg/filesystem"
+	"github.com/buildbarn/bb-remote-execution/pkg/filesystem/pool"
+	"github.com/buildbarn/bb-remote-execution/pkg/filesystem/virtual"
+	virtual_configuration "github.com/buildbarn/bb-remote-execution/pkg/filesystem/virtual/configuration"
+	virtual_pb "github.com/buildbarn/bb-remote-execution/pkg/proto/configuration/filesystem/virtual"
+	"github.com/buildbarn/bb-storage/pkg/blockdevice"
+	"github.com/buildbarn/bb-storage/pkg/clock"
+	"github.com/buildbarn/bb-storage/pkg/program"
+	"github.com/buildbarn/bb-storage/pkg/util"
+	"github.com/stretchr/testify/require"
+
+	"golang.org/x/sys/windows"
+)
+
+func findFreeDriveLetter() (string, error) {
+	for letter := 'Z'; letter >= 'A'; letter-- {
+		if _, err := os.Stat(fmt.Sprintf("%c:\\", letter)); err != nil {
+			// Drive appears to be free.
+			return string(letter), nil
+		}
+	}
+	return "", fmt.Errorf("no free drive letters available")
+}
+
+func createWinFSPMountForTest(t *testing.T, terminationGroup program.Group, caseSensitive bool) (string, blockdevice.BlockDevice) {
+	// We can't run winfsp-tests at a directory path due to
+	// https://github.com/winfsp/winfsp/issues/279. Instead find a free drive
+	// letter and run it there instead.
+	drive, err := findFreeDriveLetter()
+	require.NoError(t, err, "Failed to find free drive letter")
+	vfsPath := fmt.Sprintf(`%s:`, drive)
+
+	// Create a WinFSP mount.
+	mount, handleAllocator, err := virtual_configuration.NewMountFromConfiguration(
+		&virtual_pb.MountConfiguration{
+			MountPath: vfsPath,
+			Backend:   &virtual_pb.MountConfiguration_Winfsp{},
+		},
+		"winfsp_integration_test",
+		/* rootDirectory = */ virtual_configuration.LongAttributeCaching,
+		/* childDirectories = */ virtual_configuration.LongAttributeCaching,
+		/* leaves = */ virtual_configuration.NoAttributeCaching,
+		caseSensitive)
+	require.NoError(t, err, "Failed to create WinFSP mount")
+
+	// Create a block device to store new files.
+	bd, sectorSizeBytes, sectorCount, err := blockdevice.NewBlockDeviceFromFile(
+		path.Join(t.TempDir(), "block_device"),
+		10*1024*1024, // 10 MiB
+		false,
+	)
+	require.NoError(t, err, "Failed to create block device")
+
+	normalizer := virtual.CaseInsensitiveComponentNormalizer
+	if caseSensitive {
+		normalizer = virtual.CaseSensitiveComponentNormalizer
+	}
+
+	// Create a virtual directory to hold new files.
+	err = mount.Expose(
+		terminationGroup,
+		virtual.NewInMemoryPrepopulatedDirectory(
+			virtual.NewHandleAllocatingFileAllocator(
+				virtual.NewPoolBackedFileAllocator(
+					pool.NewBlockDeviceBackedFilePool(
+						bd,
+						filesystem.NewBitmapSectorAllocator(uint32(sectorCount)),
+						sectorSizeBytes,
+					),
+					util.DefaultErrorLogger),
+				handleAllocator),
+			virtual.NewHandleAllocatingSymlinkFactory(
+				virtual.BaseSymlinkFactory,
+				handleAllocator.New()),
+			util.DefaultErrorLogger,
+			handleAllocator,
+			sort.Sort,
+			func(s string) bool { return false },
+			clock.SystemClock,
+			normalizer,
+			/* defaultAttributesSetter = */ func(requested virtual.AttributesMask, attributes *virtual.Attributes) {
+				// No need to set ownership attributes on the top-level
+				// directory.
+				attributes.SetPermissions(virtual.PermissionsExecute | virtual.PermissionsRead)
+			}))
+	require.NoError(t, err, "Failed to expose mount point")
+
+	return vfsPath, bd
+}
+
+func runWinFSPTests(t *testing.T, terminationGroup program.Group, caseSensitive bool, testArgs []string) {
+	vfsPath, bd := createWinFSPMountForTest(t, terminationGroup, caseSensitive)
+	defer bd.Close()
+
+	winfspTestBinary, err := runfiles.Rlocation("com_github_winfsp_winfsp_tests/winfsp-tests-x64.exe")
+	if err != nil {
+		require.NoError(t, err, "Failed to locate WinFSP test binary in runfiles")
+	}
+
+	// Execute WinFSP tests
+	cmd := exec.Command(
+		winfspTestBinary,
+		append(
+			testArgs,
+			"--external",
+			"--resilient",
+			// The archive attribute is unsupported.
+			"-create_fileattr_test",
+			// PoolBackedFileAllocator doesn't support read-only mode.
+			"-create_readonlydir_test",
+			// We don't support setting file's allocation sizes.
+			"-create_allocation_test",
+			// Unsupported reparse point kinds.
+			"-reparse_guid_test",
+			"-reparse_nfs_test",
+			// Requires tracking creation time.
+			"-getfileinfo_test",
+			// Requires stream features.
+			"-stream*",
+			// Require more fine grained permissions
+			"-create_notraverse_test",
+			"-create_backup_test",
+			"-create_restore_test",
+			"-getfileattr_test",
+			"-setfileinfo_test",
+			"-delete_access_test",
+			"-setsecurity_test",
+		)...,
+	)
+	cmd.Dir = vfsPath
+
+	// Update PATH to include WinFSP install directory so that winfsp-tests
+	// can find the dll.
+	winfspInstallDir, err := ffi.BinPath()
+	require.NoError(t, err, "Could not locate WinFSP install directory")
+
+	env := os.Environ()
+	pathUpdated := false
+	for i, envVar := range env {
+		if strings.HasPrefix(strings.ToUpper(envVar), "PATH=") {
+			env[i] = envVar + ";" + winfspInstallDir
+			pathUpdated = true
+			break
+		}
+	}
+	if !pathUpdated {
+		env = append(env, "PATH="+winfspInstallDir)
+	}
+	cmd.Env = env
+
+	output, err := cmd.CombinedOutput()
+	t.Logf("WinFSP test output:\n%s", string(output))
+	require.NoError(t, err, "WinFSP test binary failed")
+}
+
+func TestWinFSPIntegration(t *testing.T) {
+	t.Run("CaseInsensitive", func(t *testing.T) {
+		program.RunLocal(context.Background(), func(ctx context.Context, siblingsGroup, dependenciesGroup program.Group) error {
+			runWinFSPTests(t, dependenciesGroup, false, []string{
+				"--case-insensitive",
+				"--case-insensitive-cmp",
+				// Requires a case insensitive but case preserving FS.
+				"-getfileinfo_name_test",
+			})
+			return nil
+		})
+	})
+
+	t.Run("CaseSensitive", func(t *testing.T) {
+		program.RunLocal(context.Background(), func(ctx context.Context, siblingsGroup, dependenciesGroup program.Group) error {
+			runWinFSPTests(t, dependenciesGroup, true, []string{
+				// Requires a case insensitive FS.
+				"-getfileinfo_name_test",
+			})
+			return nil
+		})
+	})
+}
+
+func TestWinFSPFileSystemSetSecurity(t *testing.T) {
+	program.RunLocal(context.Background(), func(ctx context.Context, siblingsGroup, dependenciesGroup program.Group) error {
+		vfsPath, bd := createWinFSPMountForTest(t, dependenciesGroup, false)
+		defer bd.Close()
+
+		testDir := filepath.Join(vfsPath, "security_test_dir")
+		err := os.Mkdir(testDir, 0o755)
+		require.NoError(t, err)
+
+		testFile := filepath.Join(vfsPath, "security_test_file.txt")
+		f, err := os.Create(testFile)
+		require.NoError(t, err)
+		_, err = f.WriteString("test content")
+		require.NoError(t, err)
+		f.Close()
+
+		testOwnerFile := filepath.Join(vfsPath, "security_test_owner_file.txt")
+		f, err = os.Create(testOwnerFile)
+		require.NoError(t, err)
+		f.Close()
+
+		t.Run("SetSecurityOnFile", func(t *testing.T) {
+			testFileUtf16, err := windows.UTF16FromString(testFile)
+			require.NoError(t, err)
+
+			h, err := windows.CreateFile(
+				&testFileUtf16[0],
+				windows.READ_CONTROL|windows.WRITE_DAC|windows.WRITE_OWNER,
+				windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+				nil,
+				windows.OPEN_EXISTING,
+				0,
+				0,
+			)
+			require.NoError(t, err, "Failed to open test file")
+			defer windows.Close(h)
+
+			sd, err := windows.GetSecurityInfo(
+				h,
+				windows.SE_FILE_OBJECT,
+				windows.DACL_SECURITY_INFORMATION,
+			)
+			require.NoError(t, err)
+
+			dacl, _, err := sd.DACL()
+			require.NoError(t, err)
+			err = windows.SetSecurityInfo(
+				h,
+				windows.SE_FILE_OBJECT,
+				windows.DACL_SECURITY_INFORMATION,
+				nil,
+				nil,
+				dacl,
+				nil,
+			)
+			require.NoError(t, err)
+		})
+
+		t.Run("SetSecurityOnDirectory", func(t *testing.T) {
+			testDirUtf16, err := windows.UTF16FromString(testDir)
+			require.NoError(t, err)
+
+			h, err := windows.CreateFile(
+				&testDirUtf16[0],
+				windows.READ_CONTROL|windows.WRITE_DAC|windows.WRITE_OWNER,
+				windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+				nil,
+				windows.OPEN_EXISTING,
+				windows.FILE_FLAG_BACKUP_SEMANTICS,
+				0,
+			)
+			require.NoError(t, err)
+			defer windows.Close(h)
+
+			sd, err := windows.GetSecurityInfo(
+				h,
+				windows.SE_FILE_OBJECT,
+				windows.DACL_SECURITY_INFORMATION,
+			)
+			require.NoError(t, err)
+
+			dacl, _, err := sd.DACL()
+			require.NoError(t, err)
+
+			err = windows.SetSecurityInfo(
+				h,
+				windows.SE_FILE_OBJECT,
+				windows.DACL_SECURITY_INFORMATION,
+				nil,
+				nil,
+				dacl,
+				nil,
+			)
+			require.NoError(t, err)
+		})
+
+		t.Run("SetSecurityWithSimpleDACL", func(t *testing.T) {
+			testFileUtf16, err := windows.UTF16FromString(testFile)
+			require.NoError(t, err)
+
+			h, err := windows.CreateFile(
+				&testFileUtf16[0],
+				windows.READ_CONTROL|windows.WRITE_DAC|windows.WRITE_OWNER,
+				windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+				nil,
+				windows.OPEN_EXISTING,
+				0,
+				0,
+			)
+			require.NoError(t, err, "Failed to open test file")
+			defer windows.Close(h)
+
+			// Create a simple security descriptor with everyone having
+			// read access.
+			everyoneSid, err := windows.CreateWellKnownSid(windows.WinWorldSid)
+			require.NoError(t, err, "Failed to create Everyone SID")
+
+			aclEntries := []windows.EXPLICIT_ACCESS{
+				{
+					AccessPermissions: windows.FILE_READ_DATA | windows.FILE_READ_ATTRIBUTES,
+					AccessMode:        windows.GRANT_ACCESS,
+					Inheritance:       windows.NO_INHERITANCE,
+					Trustee: windows.TRUSTEE{
+						TrusteeForm:  windows.TRUSTEE_IS_SID,
+						TrusteeValue: windows.TrusteeValueFromSID(everyoneSid),
+					},
+				},
+			}
+
+			dacl, err := windows.ACLFromEntries(aclEntries, nil)
+			require.NoError(t, err)
+
+			err = windows.SetSecurityInfo(
+				h,
+				windows.SE_FILE_OBJECT,
+				windows.DACL_SECURITY_INFORMATION,
+				nil,
+				nil,
+				dacl,
+				nil,
+			)
+			require.NoError(t, err)
+
+			newSd, err := windows.GetSecurityInfo(
+				h,
+				windows.SE_FILE_OBJECT,
+				windows.DACL_SECURITY_INFORMATION,
+			)
+			require.NoError(t, err)
+
+			newDacl, _, err := newSd.DACL()
+			require.NoError(t, err)
+			require.NotNil(t, newDacl)
+		})
+
+		return nil
+	})
+}
+
+func TestWinFSPFileSystemGetSecurityByNameIntegration(t *testing.T) {
+	program.RunLocal(context.Background(), func(ctx context.Context, siblingsGroup, dependenciesGroup program.Group) error {
+		vfsPath, bd := createWinFSPMountForTest(t, dependenciesGroup, false)
+		defer bd.Close()
+
+		testFile := filepath.Join(vfsPath, "security_test_file.txt")
+		f, err := os.Create(testFile)
+		require.NoError(t, err)
+		f.Close()
+
+		testDir := filepath.Join(vfsPath, "security_test_dir")
+		err = os.Mkdir(testDir, 0o755)
+		require.NoError(t, err)
+
+		symlinkTarget := filepath.Join(vfsPath, "symlink_target.txt")
+		f, err = os.Create(symlinkTarget)
+		require.NoError(t, err)
+		f.Close()
+
+		testSymlink := filepath.Join(vfsPath, "test_symlink.txt")
+		err = os.Symlink(symlinkTarget, testSymlink)
+		require.NoError(t, err)
+
+		t.Run("GetSecurityByNameOnFile", func(t *testing.T) {
+			sd, err := windows.GetNamedSecurityInfo(
+				testFile,
+				windows.SE_FILE_OBJECT,
+				windows.DACL_SECURITY_INFORMATION|windows.OWNER_SECURITY_INFORMATION|windows.GROUP_SECURITY_INFORMATION,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, sd)
+		})
+
+		t.Run("GetSecurityByNameOnDirectory", func(t *testing.T) {
+			// Get security info using Windows API
+			sd, err := windows.GetNamedSecurityInfo(
+				testDir,
+				windows.SE_FILE_OBJECT,
+				windows.DACL_SECURITY_INFORMATION|windows.OWNER_SECURITY_INFORMATION|windows.GROUP_SECURITY_INFORMATION,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, sd)
+		})
+
+		t.Run("GetSecurityByNameOnSymlink", func(t *testing.T) {
+			// Get security info for the symlink
+			sd, err := windows.GetNamedSecurityInfo(
+				testSymlink,
+				windows.SE_FILE_OBJECT,
+				windows.DACL_SECURITY_INFORMATION|windows.OWNER_SECURITY_INFORMATION|windows.GROUP_SECURITY_INFORMATION,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, sd)
+		})
+
+		return nil
+	})
+}
+
+func TestWinFSPFileSystemCasePreserving(t *testing.T) {
+	program.RunLocal(context.Background(), func(ctx context.Context, siblingsGroup, dependenciesGroup program.Group) error {
+		vfsPath, bd := createWinFSPMountForTest(t, dependenciesGroup, false)
+		defer bd.Close()
+
+		t.Run("FileCreationAndAccess", func(t *testing.T) {
+			originalFile := filepath.Join(vfsPath, "TestFile.txt")
+			f, err := os.Create(originalFile)
+			require.NoError(t, err)
+			f.Close()
+
+			for _, testPath := range []string{
+				filepath.Join(vfsPath, "testfile.txt"),
+				filepath.Join(vfsPath, "TESTFILE.TXT"),
+				filepath.Join(vfsPath, "TestFile.txt"),
+				filepath.Join(vfsPath, "testFILE.txt"),
+			} {
+				_, err := os.ReadFile(testPath)
+				require.NoError(t, err, "Failed to read file using path: %s", testPath)
+			}
+		})
+
+		t.Run("CaseInsensitiveCreateFail", func(t *testing.T) {
+			originalFile := filepath.Join(vfsPath, "CaseTestFile.txt")
+			f, err := os.OpenFile(originalFile, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+			require.NoError(t, err)
+			f.Close()
+
+			duplicateFile := filepath.Join(vfsPath, "casetestfile.txt")
+			_, err = os.OpenFile(duplicateFile, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+			require.Error(t, err)
+
+			err = os.Remove(filepath.Join(vfsPath, "CASETESTFILE.TXT"))
+			require.NoError(t, err)
+
+			_, err = os.Stat(originalFile)
+			require.Error(t, err, "File should be deleted")
+		})
+
+		t.Run("CasePreservationInListing", func(t *testing.T) {
+			items := []struct {
+				name  string
+				isDir bool
+			}{
+				{"MixedCaseFile.txt", false},
+				{"UPPERCASE.TXT", false},
+				{"lowercase.txt", false},
+				{"MixedCaseDir", true},
+				{"UPPERCASEDIR", true},
+				{"lowercasedir", true},
+			}
+
+			for _, item := range items {
+				fullPath := filepath.Join(vfsPath, item.name)
+				if item.isDir {
+					err := os.Mkdir(fullPath, 0o755)
+					require.NoError(t, err)
+				} else {
+					f, err := os.Create(fullPath)
+					require.NoError(t, err)
+					f.Close()
+				}
+			}
+
+			entries, err := os.ReadDir(vfsPath)
+			require.NoError(t, err)
+
+			foundNames := make([]string, 0, len(items))
+			for _, entry := range entries {
+				foundNames = append(foundNames, entry.Name())
+			}
+			for _, item := range items {
+				require.Contains(t, foundNames, item.name)
+			}
+		})
+
+		return nil
+	})
+}

--- a/pkg/filesystem/virtual/winfsp/file_system_test.go
+++ b/pkg/filesystem/virtual/winfsp/file_system_test.go
@@ -1,0 +1,2433 @@
+//go:build windows
+// +build windows
+
+package winfsp_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+	"unsafe"
+
+	ffi "github.com/aegistudio/go-winfsp"
+	"github.com/aegistudio/go-winfsp/filetime"
+	"github.com/buildbarn/bb-remote-execution/internal/mock"
+	"github.com/buildbarn/bb-remote-execution/pkg/filesystem/virtual"
+	"github.com/buildbarn/bb-remote-execution/pkg/filesystem/virtual/winfsp"
+	"github.com/buildbarn/bb-storage/pkg/filesystem"
+	"github.com/buildbarn/bb-storage/pkg/filesystem/path"
+	"github.com/buildbarn/bb-storage/pkg/filesystem/windowsext"
+	"github.com/stretchr/testify/require"
+
+	"golang.org/x/sys/windows"
+
+	"go.uber.org/mock/gomock"
+)
+
+// Test suite for winfspFileSystem that doesn't require WinFSP to be installed
+// These tests verify the core filesystem logic by directly testing the
+// winfspFileSystem struct methods using mock objects.
+
+type directoryEntry struct {
+	name       string
+	fileInfo   ffi.FSP_FSCTL_FILE_INFO
+	nextOffset uint64
+}
+
+// parseDirectoryBuffer parses a buffer containing FSP_FSCTL_DIR_INFO entries
+// formatted as WinFSP expects them.
+func parseDirectoryBuffer(buffer []byte) ([]directoryEntry, bool, error) {
+	var entries []directoryEntry
+	offset := 0
+	for {
+		if offset == len(buffer) {
+			// Then we've exhausted the buffer but not found the end.
+			return entries, false, nil
+		}
+		if offset == len(buffer)-2 && buffer[offset] == 0 && buffer[offset+1] == 0 {
+			// Then we've found the end marker.
+			return entries, true, nil
+		}
+
+		// Read the next entry.
+		if offset+int(unsafe.Sizeof(ffi.FSP_FSCTL_DIR_INFO{})) > len(buffer) {
+			return nil, false, fmt.Errorf("buffer was not properly terminated")
+		}
+		dirInfo := (*ffi.FSP_FSCTL_DIR_INFO)(unsafe.Pointer(&buffer[offset]))
+		dirInfoSize := int(unsafe.Sizeof(ffi.FSP_FSCTL_DIR_INFO{}))
+		nameOffset := offset + dirInfoSize
+		nameLength := int(dirInfo.Size) - dirInfoSize
+
+		// Extract the name.
+		if nameOffset+nameLength > len(buffer) {
+			return nil, false, fmt.Errorf("name overflows the end of the buffer")
+		}
+		var name string
+		if nameLength > 0 {
+			name = windows.UTF16ToString((*[1 << 30]uint16)(unsafe.Pointer(&buffer[nameOffset]))[:nameLength/2])
+		}
+
+		entries = append(entries, directoryEntry{
+			name:       name,
+			fileInfo:   dirInfo.FileInfo,
+			nextOffset: dirInfo.NextOffset,
+		})
+
+		const dirInfoAlignment uint16 = uint16(unsafe.Alignof(ffi.FSP_FSCTL_DIR_INFO{}))
+		alignedSize := (dirInfo.Size + dirInfoAlignment - 1) & ^(dirInfoAlignment - 1)
+		offset += int(alignedSize)
+	}
+}
+
+func extractSymlinkReparseTarget(buffer []byte) (string, uint32, error) {
+	if len(buffer) < int(unsafe.Sizeof(windowsext.REPARSE_DATA_BUFFER_HEADER{})) {
+		return "", 0, fmt.Errorf("buffer too small")
+	}
+	// Parse the reparse data buffer
+	reparseData := (*windowsext.REPARSE_DATA_BUFFER)(unsafe.Pointer(&buffer[0]))
+	if reparseData.ReparseTag != uint32(windows.IO_REPARSE_TAG_SYMLINK) {
+		return "", 0, fmt.Errorf("expected symlink reparse tag, got %d", windows.IO_REPARSE_TAG_SYMLINK, reparseData.ReparseTag)
+	}
+
+	symlinkData := (*windowsext.SymbolicLinkReparseBuffer)(unsafe.Pointer(&reparseData.DUMMYUNIONNAME))
+	return symlinkData.Path(), symlinkData.Flags, nil
+}
+
+func dispositionToOptions(disposition uint32) uint32 {
+	return disposition << 24
+}
+
+func getAclEntries(sd *windows.SECURITY_DESCRIPTOR) ([]*windows.ACCESS_ALLOWED_ACE, error) {
+	dacl, _, err := sd.DACL()
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]*windows.ACCESS_ALLOWED_ACE, dacl.AceCount)
+	for i := uint16(0); i < dacl.AceCount; i++ {
+		err := windows.GetAce(dacl, uint32(i), &entries[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return entries, nil
+}
+
+func TestWinFSPFileSystemCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rootDirectory := mock.NewMockVirtualDirectory(ctrl)
+	file := mock.NewMockVirtualLeaf(ctrl)
+	subdir := mock.NewMockVirtualDirectory(ctrl)
+
+	fs := winfsp.NewFileSystem(rootDirectory, false)
+	ref := &ffi.FileSystemRef{}
+
+	t.Run("CreateFileExists", func(t *testing.T) {
+		// Check the normal WinFSP sequence of Create -> Cleanup -> Close.
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("test.txt"),
+			virtual.ShareMaskWrite,
+			(&virtual.Attributes{}).SetPermissions(virtual.PermissionsExecute|virtual.PermissionsRead|virtual.PermissionsWrite),
+			&virtual.OpenExistingOptions{Truncate: true},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(123)
+			out.SetSizeBytes(0)
+			out.SetPermissions(virtual.PermissionsExecute | virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			out.SetLastDataModificationTime(time.Unix(1000, 0))
+			return file, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\test.txt",
+			windows.FILE_NON_DIRECTORY_FILE,
+			windows.FILE_WRITE_DATA,
+			0,
+			nil,
+			0,
+			&info,
+		)
+
+		require.NoError(t, err)
+		require.NotZero(t, handle)
+		require.Equal(t, uint32(windows.FILE_ATTRIBUTE_NORMAL), info.FileAttributes)
+		require.Equal(t, uint64(123), info.IndexNumber)
+		require.Equal(t, uint64(0), info.FileSize)
+
+		// Cleanup
+		file.EXPECT().VirtualSetAttributes(
+			gomock.Any(),
+			gomock.Any(),
+			virtual.AttributesMaskLastDataModificationTime,
+			gomock.Any(),
+		).Return(virtual.StatusOK)
+		fs.Cleanup(
+			ref,
+			handle,
+			"\\test.txt",
+			ffi.FspCleanupSetLastWriteTime,
+		)
+
+		// Close
+		file.EXPECT().VirtualClose(virtual.ShareMaskWrite)
+		fs.Close(ref, handle)
+	})
+
+	t.Run("OpenFileDoesNotExist", func(t *testing.T) {
+		// Simulate trying to open a file that does not exist, with
+		// disposition that does not allow creation (FILE_OPEN).
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("does_not_exist.txt"),
+			virtual.ShareMaskWrite,
+			nil,
+			&virtual.OpenExistingOptions{Truncate: false},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			return nil, 0, virtual.ChangeInfo{}, virtual.StatusErrNoEnt
+		})
+		rootDirectory.EXPECT().VirtualLookup(
+			gomock.Any(),
+			path.MustNewComponent("does_not_exist.txt"),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.DirectoryChild, virtual.Status) {
+			return virtual.DirectoryChild{}, virtual.StatusErrNoEnt
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\does_not_exist.txt",
+			dispositionToOptions(windows.FILE_OPEN),
+			windows.FILE_WRITE_DATA,
+			0,
+			nil,
+			0,
+			&info,
+		)
+
+		require.Error(t, err)
+		require.Zero(t, handle)
+	})
+
+	t.Run("CreateFileDoesNotExist", func(t *testing.T) {
+		// Simulate trying to open a file that does not exist, with
+		// disposition that does allow creation (FILE_OPEN).
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("does_not_exist.txt"),
+			virtual.ShareMaskWrite,
+			(&virtual.Attributes{}).SetPermissions(virtual.PermissionsExecute|virtual.PermissionsRead|virtual.PermissionsWrite),
+			nil,
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(123)
+			out.SetSizeBytes(0)
+			out.SetPermissions(virtual.PermissionsExecute | virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			out.SetLastDataModificationTime(time.Unix(1000, 0))
+			return file, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\does_not_exist.txt",
+			dispositionToOptions(windows.FILE_CREATE),
+			windows.FILE_WRITE_DATA,
+			0,
+			nil,
+			0,
+			&info,
+		)
+
+		require.NoError(t, err)
+		require.NotZero(t, handle)
+		require.Equal(t, uint32(windows.FILE_ATTRIBUTE_NORMAL), info.FileAttributes)
+		require.Equal(t, uint64(123), info.IndexNumber)
+		require.Equal(t, uint64(0), info.FileSize)
+	})
+
+	t.Run("CreateDirectoryLookupOnOpenFail", func(t *testing.T) {
+		// Check that if calling VirtualOpen fails because the item is a
+		// directory, we use VirtualLookup instead.
+		//
+		// This simulates a failure found when testing with bonanza.
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("subdir"),
+			virtual.ShareMaskWrite,
+			nil,
+			&virtual.OpenExistingOptions{},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			// This is how bonanza implements this function.
+			return virtual.ReadOnlyDirectoryOpenChildDoesntExist(createAttributes)
+		})
+		rootDirectory.EXPECT().VirtualLookup(
+			gomock.Any(),
+			path.MustNewComponent("subdir"),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.DirectoryChild, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeDirectory)
+			out.SetInodeNumber(123)
+			out.SetPermissions(virtual.PermissionsExecute | virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			out.SetLastDataModificationTime(time.Unix(1000, 0))
+			return virtual.DirectoryChild{}.FromDirectory(subdir), virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\subdir",
+			dispositionToOptions(windows.FILE_OPEN),
+			windows.FILE_WRITE_DATA,
+			0,
+			nil,
+			0,
+			&info,
+		)
+		require.NoError(t, err)
+		require.NotZero(t, handle)
+		require.Equal(t, uint32(windows.FILE_ATTRIBUTE_DIRECTORY), info.FileAttributes)
+
+		// We don't expect a close.
+		fs.Close(ref, handle)
+	})
+}
+
+func TestWinFSPFileSystemOpen(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rootDirectory := mock.NewMockVirtualDirectory(ctrl)
+	file := mock.NewMockVirtualLeaf(ctrl)
+
+	fs := winfsp.NewFileSystem(rootDirectory, false)
+	ref := &ffi.FileSystemRef{}
+
+	t.Run("OpenExistingFile", func(t *testing.T) {
+		// Open a file that does exist.
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("existing.txt"),
+			virtual.ShareMaskRead,
+			nil,
+			&virtual.OpenExistingOptions{},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			// Return attributes for an existing file
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(456)
+			out.SetSizeBytes(100)
+			out.SetPermissions(virtual.PermissionsRead)
+			out.SetLinkCount(1)
+			out.SetLastDataModificationTime(time.Unix(2000, 0))
+			return file, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Open(
+			ref,
+			"\\existing.txt",
+			dispositionToOptions(windows.FILE_OPEN),
+			windows.FILE_READ_DATA,
+			&info,
+		)
+
+		require.NoError(t, err)
+		require.NotZero(t, handle)
+		require.Equal(t, uint32(windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_ATTRIBUTE_READONLY), info.FileAttributes)
+		require.Equal(t, uint64(456), info.IndexNumber)
+		require.Equal(t, uint64(100), info.FileSize)
+	})
+
+	t.Run("OpenNonExistentFile", func(t *testing.T) {
+		// Open a file that does not exist.
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("does_not_exist.txt"),
+			virtual.ShareMaskRead,
+			nil,
+			&virtual.OpenExistingOptions{},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			return nil, 0, virtual.ChangeInfo{}, virtual.StatusErrNoEnt
+		})
+		rootDirectory.EXPECT().VirtualLookup(
+			gomock.Any(),
+			path.MustNewComponent("does_not_exist.txt"),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.DirectoryChild, virtual.Status) {
+			return virtual.DirectoryChild{}, virtual.StatusErrNoEnt
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Open(
+			ref,
+			"\\does_not_exist.txt",
+			dispositionToOptions(windows.FILE_OPEN),
+			windows.FILE_READ_DATA,
+			&info,
+		)
+
+		require.Error(t, err)
+		require.Zero(t, handle)
+	})
+}
+
+func TestWinFSPFileSystemRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rootDirectory := mock.NewMockVirtualDirectory(ctrl)
+	file := mock.NewMockVirtualLeaf(ctrl)
+
+	fs := winfsp.NewFileSystem(rootDirectory, false)
+	ref := &ffi.FileSystemRef{}
+
+	fileName := "\\read_test.txt"
+	expectedContent := []byte("Test file content")
+
+	t.Run("ReadFromFile", func(t *testing.T) {
+		// Create the file
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("read_test.txt"),
+			virtual.ShareMaskRead,
+			(&virtual.Attributes{}).SetPermissions(virtual.PermissionsExecute|virtual.PermissionsRead|virtual.PermissionsWrite),
+			&virtual.OpenExistingOptions{Truncate: true},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(789)
+			out.SetSizeBytes(uint64(len(expectedContent)))
+			out.SetPermissions(virtual.PermissionsRead)
+			out.SetLinkCount(1)
+			return file, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			fileName,
+			0,
+			windows.FILE_READ_DATA,
+			0,
+			nil,
+			0,
+			&info,
+		)
+		require.NoError(t, err)
+
+		// Read and validate the data
+		file.EXPECT().VirtualRead(
+			gomock.Any(),
+			uint64(0),
+		).DoAndReturn(func(buffer []byte, offset uint64) (int, bool, virtual.Status) {
+			n := copy(buffer, expectedContent)
+			return n, false, virtual.StatusOK
+		})
+
+		buffer := make([]byte, 100)
+		bytesRead, err := fs.Read(ref, handle, buffer, 0)
+
+		require.NoError(t, err)
+		require.Equal(t, len(expectedContent), bytesRead)
+		require.Equal(t, expectedContent, buffer[:bytesRead])
+	})
+}
+
+func TestWinFSPFileSystemWrite(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rootDirectory := mock.NewMockVirtualDirectory(ctrl)
+	file := mock.NewMockVirtualLeaf(ctrl)
+
+	fs := winfsp.NewFileSystem(rootDirectory, false)
+	ref := &ffi.FileSystemRef{}
+
+	t.Run("WriteToFile", func(t *testing.T) {
+		// Create a file
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("test.txt"),
+			virtual.ShareMaskWrite,
+			(&virtual.Attributes{}).SetPermissions(virtual.PermissionsExecute|virtual.PermissionsRead|virtual.PermissionsWrite),
+			&virtual.OpenExistingOptions{Truncate: true},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(123)
+			out.SetSizeBytes(0)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			out.SetLastDataModificationTime(time.Unix(1000, 0))
+			return file, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\test.txt",
+			windows.FILE_NON_DIRECTORY_FILE,
+			windows.FILE_WRITE_DATA,
+			0,
+			nil,
+			0,
+			&info,
+		)
+		require.NoError(t, err)
+
+		// Write to the file
+		fileContent := []byte("Hello, World!")
+		file.EXPECT().VirtualWrite(
+			fileContent,
+			uint64(0), // offset
+		).Return(len(fileContent), virtual.StatusOK)
+
+		// Expect the file attributes to be queried after write
+		file.EXPECT().VirtualGetAttributes(
+			gomock.Any(),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).Do(func(ctx context.Context, requested virtual.AttributesMask, attributes *virtual.Attributes) {
+			attributes.SetFileType(filesystem.FileTypeRegularFile)
+			attributes.SetInodeNumber(123)
+			attributes.SetSizeBytes(uint64(len(fileContent)))
+			attributes.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			attributes.SetLinkCount(1)
+			attributes.SetLastDataModificationTime(time.Unix(1001, 0))
+		})
+
+		var writeInfo ffi.FSP_FSCTL_FILE_INFO
+		written, err := fs.Write(
+			ref,
+			handle,
+			fileContent,
+			0,
+			false,
+			false,
+			&writeInfo,
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, len(fileContent), written)
+		require.Equal(t, uint64(len(fileContent)), writeInfo.FileSize)
+	})
+}
+
+func TestWinFSPFileSystemReadDirectoryOffset(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rootDirectory := mock.NewMockVirtualDirectory(ctrl)
+	subDirectory := mock.NewMockVirtualDirectory(ctrl)
+
+	fs := winfsp.NewFileSystem(rootDirectory, false)
+	ref := &ffi.FileSystemRef{}
+
+	t.Run("ReadRootDirectory", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualGetAttributes(
+			gomock.Any(),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).Do(func(ctx context.Context, requested virtual.AttributesMask, attributes *virtual.Attributes) {
+			attributes.SetFileType(filesystem.FileTypeDirectory)
+			attributes.SetInodeNumber(1)
+			attributes.SetSizeBytes(0)
+			attributes.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			attributes.SetLinkCount(1)
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\",
+			dispositionToOptions(windows.FILE_OPEN)|windows.FILE_DIRECTORY_FILE,
+			windows.FILE_LIST_DIRECTORY,
+			0,
+			nil,
+			0,
+			&info,
+		)
+		require.NoError(t, err)
+
+		// Mock directory reading
+		rootDirectory.EXPECT().VirtualReadDir(
+			gomock.Any(),
+			uint64(0),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, firstCookie uint64, attributesMask virtual.AttributesMask, reporter virtual.DirectoryEntryReporter) virtual.Status {
+			// Report a file entry
+			attrs := virtual.Attributes{}
+			attrs.SetFileType(filesystem.FileTypeRegularFile)
+			attrs.SetInodeNumber(100)
+			attrs.SetSizeBytes(42)
+			attrs.SetPermissions(virtual.PermissionsRead)
+			attrs.SetLinkCount(1)
+
+			child := virtual.DirectoryChild{}.FromLeaf(mock.NewMockVirtualLeaf(ctrl))
+			require.True(t, reporter.ReportEntry(1, path.MustNewComponent("file1.txt"), child, &attrs))
+			return virtual.StatusOK
+		})
+
+		buffer := make([]byte, 1024)
+		bytesWritten, err := fs.ReadDirectoryOffset(ref, handle, nil, 0, buffer)
+		require.NoError(t, err)
+		require.LessOrEqual(t, bytesWritten, len(buffer))
+
+		// Validate the entries.
+		entries, finished, err := parseDirectoryBuffer(buffer[:bytesWritten])
+		require.NoError(t, err)
+		require.True(t, finished)
+		require.Len(t, entries, 1)
+
+		require.Equal(t, "file1.txt", entries[0].name)
+		require.Equal(t, uint64(100), entries[0].fileInfo.IndexNumber)
+		require.Equal(t, uint64(42), entries[0].fileInfo.FileSize)
+		require.Equal(t, uint32(windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_ATTRIBUTE_READONLY), entries[0].fileInfo.FileAttributes)
+	})
+
+	t.Run("ReadSubDirectory", func(t *testing.T) {
+		// Check for sub directories we get . and .. entries.
+
+		rootDirectory.EXPECT().VirtualLookup(
+			gomock.Any(),
+			path.MustNewComponent("subdir"),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.DirectoryChild, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeDirectory)
+			out.SetInodeNumber(200)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsExecute)
+			out.SetLinkCount(1)
+			return virtual.DirectoryChild{}.FromDirectory(subDirectory), virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\subdir",
+			dispositionToOptions(windows.FILE_OPEN)|windows.FILE_DIRECTORY_FILE,
+			windows.FILE_LIST_DIRECTORY,
+			0,
+			nil,
+			0,
+			&info,
+		)
+		require.NoError(t, err)
+
+		subDirectory.EXPECT().VirtualReadDir(
+			gomock.Any(),
+			uint64(0),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, firstCookie uint64, attributesMask virtual.AttributesMask, reporter virtual.DirectoryEntryReporter) virtual.Status {
+			// Report one entry
+			attrs := virtual.Attributes{}
+			attrs.SetFileType(filesystem.FileTypeRegularFile)
+			attrs.SetInodeNumber(300)
+			attrs.SetSizeBytes(0)
+			attrs.SetPermissions(virtual.PermissionsRead)
+			attrs.SetLinkCount(1)
+
+			child := virtual.DirectoryChild{}.FromLeaf(mock.NewMockVirtualLeaf(ctrl))
+			require.True(t, reporter.ReportEntry(1, path.MustNewComponent("nested.txt"), child, &attrs))
+			return virtual.StatusOK
+		})
+
+		buffer := make([]byte, 1024)
+		bytesWritten, err := fs.ReadDirectoryOffset(ref, handle, nil, 0, buffer)
+		require.NoError(t, err)
+		require.LessOrEqual(t, bytesWritten, len(buffer))
+
+		// Validate the entries.
+		entries, finished, err := parseDirectoryBuffer(buffer[:bytesWritten])
+		require.NoError(t, err)
+		require.True(t, finished)
+		require.Len(t, entries, 3)
+
+		require.Equal(t, ".", entries[0].name)
+		require.Equal(t, uint32(windows.FILE_ATTRIBUTE_DIRECTORY), entries[0].fileInfo.FileAttributes)
+
+		require.Equal(t, "..", entries[1].name)
+		require.Equal(t, uint32(windows.FILE_ATTRIBUTE_DIRECTORY), entries[1].fileInfo.FileAttributes)
+
+		require.Equal(t, "nested.txt", entries[2].name)
+		require.Equal(t, uint64(300), entries[2].fileInfo.IndexNumber)
+		require.Equal(t, uint64(0), entries[2].fileInfo.FileSize)
+		require.Equal(t, uint32(windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_ATTRIBUTE_READONLY), entries[2].fileInfo.FileAttributes)
+	})
+
+	t.Run("ReadSubDirectoryWithPagination", func(t *testing.T) {
+		// Test reading a subdirectory where the buffer is too small for
+		// all entries, requiring multiple calls with different offsets.
+
+		// Create mock objects
+		attrs1 := virtual.Attributes{}
+		attrs1.SetFileType(filesystem.FileTypeRegularFile)
+		attrs1.SetInodeNumber(400)
+		attrs1.SetSizeBytes(10)
+		attrs1.SetPermissions(virtual.PermissionsRead)
+		attrs1.SetLinkCount(1)
+		child1 := virtual.DirectoryChild{}.FromLeaf(mock.NewMockVirtualLeaf(ctrl))
+
+		attrs2 := virtual.Attributes{}
+		attrs2.SetFileType(filesystem.FileTypeRegularFile)
+		attrs2.SetInodeNumber(401)
+		attrs2.SetSizeBytes(20)
+		attrs2.SetPermissions(virtual.PermissionsRead)
+		attrs2.SetLinkCount(1)
+		child2 := virtual.DirectoryChild{}.FromLeaf(mock.NewMockVirtualLeaf(ctrl))
+
+		attrs3 := virtual.Attributes{}
+		attrs3.SetFileType(filesystem.FileTypeRegularFile)
+		attrs3.SetInodeNumber(402)
+		attrs3.SetSizeBytes(30)
+		attrs3.SetPermissions(virtual.PermissionsRead)
+		attrs3.SetLinkCount(1)
+
+		child3 := virtual.DirectoryChild{}.FromLeaf(mock.NewMockVirtualLeaf(ctrl))
+
+		rootDirectory.EXPECT().VirtualLookup(
+			gomock.Any(),
+			path.MustNewComponent("bigdir"),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.DirectoryChild, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeDirectory)
+			out.SetInodeNumber(300)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsExecute)
+			out.SetLinkCount(1)
+			return virtual.DirectoryChild{}.FromDirectory(subDirectory), virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\bigdir",
+			dispositionToOptions(windows.FILE_OPEN)|windows.FILE_DIRECTORY_FILE,
+			windows.FILE_LIST_DIRECTORY,
+			0,
+			nil,
+			0,
+			&info,
+		)
+		require.NoError(t, err)
+
+		// First call: VirtualReadDir with cookie 0, returns first 2 entries.
+		subDirectory.EXPECT().VirtualReadDir(
+			gomock.Any(),
+			uint64(0),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, firstCookie uint64, attributesMask virtual.AttributesMask, reporter virtual.DirectoryEntryReporter) virtual.Status {
+			require.True(t, reporter.ReportEntry(1, path.MustNewComponent("file1.txt"), child1, &attrs1))
+			// Should be exhausted.
+			require.False(t, reporter.ReportEntry(2, path.MustNewComponent("file2.txt"), child2, &attrs2))
+			return virtual.StatusOK
+		})
+
+		// Use a small buffer that can only fit "." + ".." + one file entry.
+		buffer1 := make([]byte, 400)
+		bytesWritten1, err := fs.ReadDirectoryOffset(ref, handle, nil, 0, buffer1)
+		require.NoError(t, err)
+		require.Greater(t, bytesWritten1, 0)
+
+		// Check the first batch.
+		entries1, finished1, err := parseDirectoryBuffer(buffer1[:bytesWritten1])
+		require.NoError(t, err)
+		require.False(t, finished1)
+		require.Len(t, entries1, 3)
+		require.Equal(t, ".", entries1[0].name)
+		require.Equal(t, "..", entries1[1].name)
+		require.Equal(t, "file1.txt", entries1[2].name)
+
+		// Second call: VirtualReadDir with cookie 1 (offset by 2 for "." and "..").
+		subDirectory.EXPECT().VirtualReadDir(
+			gomock.Any(),
+			uint64(1),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, firstCookie uint64, attributesMask virtual.AttributesMask, reporter virtual.DirectoryEntryReporter) virtual.Status {
+			require.True(t, reporter.ReportEntry(2, path.MustNewComponent("file2.txt"), child2, &attrs2))
+			require.True(t, reporter.ReportEntry(3, path.MustNewComponent("file3.txt"), child3, &attrs3))
+			return virtual.StatusOK
+		})
+
+		buffer2 := make([]byte, 1024)
+		bytesWritten2, err := fs.ReadDirectoryOffset(ref, handle, nil, entries1[2].nextOffset, buffer2)
+		require.NoError(t, err)
+
+		// Parse the second batch.
+		entries2, finished2, err := parseDirectoryBuffer(buffer2[:bytesWritten2])
+		require.NoError(t, err)
+		require.True(t, finished2)
+		require.Len(t, entries2, 2)
+
+		require.Equal(t, "file2.txt", entries2[0].name)
+		require.Equal(t, "file3.txt", entries2[1].name)
+	})
+}
+
+func TestWinFSPFileSystemGetFileInfo(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rootDirectory := mock.NewMockVirtualDirectory(ctrl)
+	file := mock.NewMockVirtualLeaf(ctrl)
+
+	fs := winfsp.NewFileSystem(rootDirectory, false)
+	ref := &ffi.FileSystemRef{}
+
+	t.Run("GetFileInfoSuccess", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("info_test.txt"),
+			virtual.ShareMaskRead,
+			(&virtual.Attributes{}).SetPermissions(virtual.PermissionsExecute|virtual.PermissionsRead|virtual.PermissionsWrite),
+			&virtual.OpenExistingOptions{Truncate: true},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(500)
+			out.SetSizeBytes(256)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			out.SetLastDataModificationTime(time.Unix(3000, 0))
+			return file, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var createInfo ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\info_test.txt",
+			0,
+			windows.FILE_READ_DATA,
+			0,
+			nil,
+			0,
+			&createInfo,
+		)
+		require.NoError(t, err)
+
+		file.EXPECT().VirtualGetAttributes(
+			gomock.Any(),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).Do(func(ctx context.Context, requested virtual.AttributesMask, attributes *virtual.Attributes) {
+			attributes.SetFileType(filesystem.FileTypeRegularFile)
+			attributes.SetInodeNumber(500)
+			attributes.SetSizeBytes(256)
+			attributes.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			attributes.SetLinkCount(1)
+			attributes.SetLastDataModificationTime(time.Unix(3000, 0))
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		err = fs.GetFileInfo(ref, handle, &info)
+
+		require.NoError(t, err)
+		require.Equal(t, uint32(windows.FILE_ATTRIBUTE_NORMAL), info.FileAttributes)
+		require.Equal(t, uint64(500), info.IndexNumber)
+		require.Equal(t, uint64(256), info.FileSize)
+	})
+}
+
+func TestWinFSPFileSystemGetVolumeInfo(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rootDirectory := mock.NewMockVirtualDirectory(ctrl)
+
+	fs := winfsp.NewFileSystem(rootDirectory, false)
+	ref := &ffi.FileSystemRef{}
+
+	t.Run("GetVolumeInfoDefault", func(t *testing.T) {
+		var info ffi.FSP_FSCTL_VOLUME_INFO
+		err := fs.GetVolumeInfo(ref, &info)
+
+		require.NoError(t, err)
+		require.Equal(t, uint64(0), info.FreeSize)
+		require.Equal(t, uint64(0), info.TotalSize)
+		require.Equal(t, uint16(0), info.VolumeLabelLength)
+	})
+
+	t.Run("SetVolumeLabel", func(t *testing.T) {
+		var setInfo ffi.FSP_FSCTL_VOLUME_INFO
+		err := fs.SetVolumeLabel(ref, "TestVolume", &setInfo)
+		require.NoError(t, err)
+
+		var getInfo ffi.FSP_FSCTL_VOLUME_INFO
+		err = fs.GetVolumeInfo(ref, &getInfo)
+		require.NoError(t, err)
+		require.Equal(t, uint64(0), getInfo.FreeSize)
+		require.Equal(t, uint64(0), getInfo.TotalSize)
+		require.Equal(t, "TestVolume", windows.UTF16ToString(getInfo.VolumeLabel[:]))
+	})
+}
+
+func TestWinFSPFileSystemSetFileSize(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rootDirectory := mock.NewMockVirtualDirectory(ctrl)
+	file := mock.NewMockVirtualLeaf(ctrl)
+
+	fs := winfsp.NewFileSystem(rootDirectory, false)
+	ref := &ffi.FileSystemRef{}
+
+	t.Run("SetFileSizeSuccess", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("resize_test.txt"),
+			virtual.ShareMaskWrite,
+			(&virtual.Attributes{}).SetPermissions(virtual.PermissionsExecute|virtual.PermissionsRead|virtual.PermissionsWrite),
+			&virtual.OpenExistingOptions{Truncate: true},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(600)
+			out.SetSizeBytes(100)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			return file, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var createInfo ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\resize_test.txt",
+			0,
+			windows.FILE_WRITE_DATA,
+			0,
+			nil,
+			0,
+			&createInfo,
+		)
+		require.NoError(t, err)
+
+		// Set new file size
+		newSize := uint64(200)
+		file.EXPECT().VirtualSetAttributes(
+			gomock.Any(),
+			gomock.Any(),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, in *virtual.Attributes, attributesMask virtual.AttributesMask, out *virtual.Attributes) virtual.Status {
+			size, _ := in.GetSizeBytes()
+			require.Equal(t, newSize, size)
+
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(600)
+			out.SetSizeBytes(newSize)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			return virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		err = fs.SetFileSize(ref, handle, newSize, false, &info)
+
+		require.NoError(t, err)
+		require.Equal(t, newSize, info.FileSize)
+	})
+}
+
+func TestWinFSPFileSystemCanDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rootDirectory := mock.NewMockVirtualDirectory(ctrl)
+	file := mock.NewMockVirtualLeaf(ctrl)
+	emptyDir := mock.NewMockVirtualDirectory(ctrl)
+	nonEmptyDir := mock.NewMockVirtualDirectory(ctrl)
+
+	fs := winfsp.NewFileSystem(rootDirectory, false)
+	ref := &ffi.FileSystemRef{}
+
+	t.Run("CanDeleteFile", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("deletable.txt"),
+			virtual.ShareMaskRead,
+			(&virtual.Attributes{}).SetPermissions(virtual.PermissionsExecute|virtual.PermissionsRead|virtual.PermissionsWrite),
+			&virtual.OpenExistingOptions{Truncate: true},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(600)
+			out.SetSizeBytes(100)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			return file, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(ref, "\\deletable.txt", 0, windows.FILE_READ_DATA, 0, nil, 0, &info)
+		require.NoError(t, err)
+
+		err = fs.CanDelete(ref, handle, "\\deletable.txt")
+		require.NoError(t, err)
+	})
+
+	t.Run("CanDeleteEmptyDirectory", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualLookup(
+			gomock.Any(),
+			path.MustNewComponent("empty_dir"),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.DirectoryChild, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeDirectory)
+			out.SetInodeNumber(600)
+			out.SetSizeBytes(100)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			return virtual.DirectoryChild{}.FromDirectory(emptyDir), virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(ref, "\\empty_dir", dispositionToOptions(windows.FILE_OPEN)|windows.FILE_DIRECTORY_FILE, windows.FILE_READ_DATA, 0, nil, 0, &info)
+		require.NoError(t, err)
+
+		// Mock empty directory check.
+		emptyDir.EXPECT().VirtualReadDir(
+			gomock.Any(),
+			uint64(0),
+			virtual.AttributesMask(0),
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, firstCookie uint64, attributesMask virtual.AttributesMask, reporter virtual.DirectoryEntryReporter) virtual.Status {
+			return virtual.StatusOK
+		})
+
+		err = fs.CanDelete(ref, handle, "\\empty_dir")
+		require.NoError(t, err)
+	})
+
+	t.Run("CannotDeleteNonEmptyDirectory", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualLookup(
+			gomock.Any(),
+			path.MustNewComponent("nonempty_dir"),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.DirectoryChild, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeDirectory)
+			out.SetInodeNumber(600)
+			out.SetSizeBytes(100)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			return virtual.DirectoryChild{}.FromDirectory(nonEmptyDir), virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(ref, "\\nonempty_dir", dispositionToOptions(windows.FILE_OPEN)|windows.FILE_DIRECTORY_FILE, windows.FILE_READ_DATA, 0, nil, 0, &info)
+		require.NoError(t, err)
+
+		// Mock non-empty directory check.
+		nonEmptyDir.EXPECT().VirtualReadDir(
+			gomock.Any(),
+			uint64(0),
+			virtual.AttributesMask(0),
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, firstCookie uint64, attributesMask virtual.AttributesMask, reporter virtual.DirectoryEntryReporter) virtual.Status {
+			attrs := virtual.Attributes{}
+			child := virtual.DirectoryChild{}.FromLeaf(mock.NewMockVirtualLeaf(ctrl))
+			reporter.ReportEntry(1, path.MustNewComponent("some_file.txt"), child, &attrs)
+			return virtual.StatusOK
+		})
+
+		err = fs.CanDelete(ref, handle, "\\nonempty_dir")
+		require.Error(t, err)
+		require.Equal(t, windows.STATUS_DIRECTORY_NOT_EMPTY, err)
+	})
+}
+
+func TestWinFSPFileSystemRename(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rootDirectory := mock.NewMockVirtualDirectory(ctrl)
+	file := mock.NewMockVirtualLeaf(ctrl)
+
+	fs := winfsp.NewFileSystem(rootDirectory, false)
+	ref := &ffi.FileSystemRef{}
+
+	t.Run("RenameFileSuccess", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("oldname.txt"),
+			virtual.ShareMaskWrite,
+			(&virtual.Attributes{}).SetPermissions(virtual.PermissionsExecute|virtual.PermissionsRead|virtual.PermissionsWrite),
+			&virtual.OpenExistingOptions{Truncate: true},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(600)
+			out.SetSizeBytes(100)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			return file, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(ref, "\\oldname.txt", 0, windows.FILE_WRITE_DATA, 0, nil, 0, &info)
+		require.NoError(t, err)
+
+		rootDirectory.EXPECT().VirtualLookup(
+			gomock.Any(),
+			path.MustNewComponent("newname.txt"),
+			virtual.AttributesMaskFileType,
+			gomock.Any(),
+		).Return(virtual.DirectoryChild{}, virtual.StatusErrNoEnt)
+
+		rootDirectory.EXPECT().VirtualRename(
+			path.MustNewComponent("oldname.txt"),
+			rootDirectory,
+			path.MustNewComponent("newname.txt"),
+		).Return(virtual.ChangeInfo{}, virtual.ChangeInfo{}, virtual.StatusOK)
+
+		err = fs.Rename(ref, handle, "\\oldname.txt", "\\newname.txt", false)
+		require.NoError(t, err)
+	})
+
+	t.Run("RenameFileTargetExists", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("source.txt"),
+			virtual.ShareMaskWrite,
+			(&virtual.Attributes{}).SetPermissions(virtual.PermissionsExecute|virtual.PermissionsRead|virtual.PermissionsWrite),
+			&virtual.OpenExistingOptions{Truncate: true},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(600)
+			out.SetSizeBytes(100)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			return file, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(ref, "\\source.txt", 0, windows.FILE_WRITE_DATA, 0, nil, 0, &info)
+		require.NoError(t, err)
+
+		targetFile := mock.NewMockVirtualLeaf(ctrl)
+		rootDirectory.EXPECT().VirtualLookup(
+			gomock.Any(),
+			path.MustNewComponent("target.txt"),
+			virtual.AttributesMaskFileType,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.DirectoryChild, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(601)
+			out.SetSizeBytes(100)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			return virtual.DirectoryChild{}.FromLeaf(targetFile), virtual.StatusOK
+		})
+
+		err = fs.Rename(ref, handle, "\\source.txt", "\\target.txt", false)
+		require.Error(t, err)
+		require.Equal(t, windows.STATUS_OBJECT_NAME_COLLISION, err)
+	})
+
+	t.Run("RenameFileReplaceExisting", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("source.txt"),
+			virtual.ShareMaskWrite,
+			(&virtual.Attributes{}).SetPermissions(virtual.PermissionsExecute|virtual.PermissionsRead|virtual.PermissionsWrite),
+			&virtual.OpenExistingOptions{Truncate: true},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(600)
+			out.SetSizeBytes(100)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			return file, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(ref, "\\source.txt", 0, windows.FILE_WRITE_DATA, 0, nil, 0, &info)
+		require.NoError(t, err)
+
+		targetFile := mock.NewMockVirtualLeaf(ctrl)
+		rootDirectory.EXPECT().VirtualLookup(
+			gomock.Any(),
+			path.MustNewComponent("target.txt"),
+			virtual.AttributesMaskFileType,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.DirectoryChild, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(601)
+			out.SetSizeBytes(100)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			return virtual.DirectoryChild{}.FromLeaf(targetFile), virtual.StatusOK
+		})
+
+		rootDirectory.EXPECT().VirtualRename(
+			path.MustNewComponent("source.txt"),
+			rootDirectory,
+			path.MustNewComponent("target.txt"),
+		).Return(virtual.ChangeInfo{}, virtual.ChangeInfo{}, virtual.StatusOK)
+
+		err = fs.Rename(ref, handle, "\\source.txt", "\\target.txt", true)
+		require.NoError(t, err)
+	})
+
+	t.Run("RenameFileToSameFile", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("samefile.txt"),
+			virtual.ShareMaskWrite,
+			(&virtual.Attributes{}).SetPermissions(virtual.PermissionsExecute|virtual.PermissionsRead|virtual.PermissionsWrite),
+			&virtual.OpenExistingOptions{Truncate: true},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(600)
+			out.SetSizeBytes(100)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			return file, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(ref, "\\samefile.txt", 0, windows.FILE_WRITE_DATA, 0, nil, 0, &info)
+		require.NoError(t, err)
+
+		rootDirectory.EXPECT().VirtualLookup(
+			gomock.Any(),
+			path.MustNewComponent("samefile.txt"),
+			virtual.AttributesMaskFileType,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.DirectoryChild, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(600)
+			out.SetSizeBytes(100)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			return virtual.DirectoryChild{}.FromLeaf(file), virtual.StatusOK
+		})
+
+		rootDirectory.EXPECT().VirtualRename(
+			path.MustNewComponent("samefile.txt"),
+			rootDirectory,
+			path.MustNewComponent("samefile.txt"),
+		).Return(virtual.ChangeInfo{}, virtual.ChangeInfo{}, virtual.StatusOK)
+
+		err = fs.Rename(ref, handle, "\\samefile.txt", "\\samefile.txt", false)
+		require.NoError(t, err)
+	})
+}
+
+func TestWinFSPFileSystemOverwrite(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rootDirectory := mock.NewMockVirtualDirectory(ctrl)
+	file := mock.NewMockVirtualLeaf(ctrl)
+
+	fs := winfsp.NewFileSystem(rootDirectory, false)
+	ref := &ffi.FileSystemRef{}
+
+	t.Run("OverwriteFile", func(t *testing.T) {
+		// Create a file
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("overwrite_test.txt"),
+			virtual.ShareMaskWrite,
+			(&virtual.Attributes{}).SetPermissions(virtual.PermissionsExecute|virtual.PermissionsRead|virtual.PermissionsWrite),
+			&virtual.OpenExistingOptions{Truncate: true},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(700)
+			out.SetSizeBytes(100)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			return file, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var createInfo ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(ref, "\\overwrite_test.txt", 0, windows.FILE_WRITE_DATA, 0, nil, 0, &createInfo)
+		require.NoError(t, err)
+
+		// Mock overwrite operation
+		file.EXPECT().VirtualSetAttributes(
+			gomock.Any(),
+			gomock.Any(),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, in *virtual.Attributes, attributesMask virtual.AttributesMask, out *virtual.Attributes) virtual.Status {
+			size, present := in.GetSizeBytes()
+			require.True(t, present)
+			require.Equal(t, uint64(0), size)
+
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(700)
+			out.SetSizeBytes(0)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			return virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		err = fs.Overwrite(ref, handle, 0, true, 0, &info)
+
+		require.NoError(t, err)
+		require.Equal(t, uint64(0), info.FileSize)
+	})
+}
+
+func TestWinFSPFileSystemGetReparsePointByName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rootDirectory := mock.NewMockVirtualDirectory(ctrl)
+	symlink := mock.NewMockVirtualLeaf(ctrl)
+
+	fs := winfsp.NewFileSystem(rootDirectory, false)
+	ref := &ffi.FileSystemRef{}
+
+	t.Run("GetSymlinkReparsePoint", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualLookup(
+			gomock.Any(),
+			path.MustNewComponent("symlink.txt"),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.DirectoryChild, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeSymlink)
+			out.SetInodeNumber(800)
+			out.SetPermissions(virtual.PermissionsRead)
+			out.SetLinkCount(1)
+			return virtual.DirectoryChild{}.FromLeaf(symlink), virtual.StatusOK
+		})
+
+		// Mock readlink
+		target := []byte("target.txt")
+		symlink.EXPECT().VirtualReadlink(gomock.Any()).Return(target, virtual.StatusOK)
+
+		buffer := make([]byte, 1024)
+		bytesWritten, err := fs.GetReparsePointByName(ref, "\\symlink.txt", false, buffer)
+		require.NoError(t, err)
+		actualTarget, flags, err := extractSymlinkReparseTarget(buffer[:bytesWritten])
+		require.NoError(t, err)
+		require.Equal(t, "target.txt", string(actualTarget))
+		require.Equal(t, uint32(windowsext.SYMLINK_FLAG_RELATIVE), flags)
+	})
+
+	t.Run("GetReparsePointForRegularFile", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualLookup(
+			gomock.Any(),
+			path.MustNewComponent("regular.txt"),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.DirectoryChild, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			return virtual.DirectoryChild{}.FromLeaf(mock.NewMockVirtualLeaf(ctrl)), virtual.StatusOK
+		})
+
+		buffer := make([]byte, 1024)
+		_, err := fs.GetReparsePointByName(ref, "\\regular.txt", false, buffer)
+		require.Error(t, err)
+		require.Equal(t, windows.STATUS_NOT_A_REPARSE_POINT, err)
+	})
+}
+
+func TestWinFSPFileSystemGetReparsePoint(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rootDirectory := mock.NewMockVirtualDirectory(ctrl)
+	symlink := mock.NewMockVirtualLeaf(ctrl)
+	regularFile := mock.NewMockVirtualLeaf(ctrl)
+
+	fs := winfsp.NewFileSystem(rootDirectory, false)
+	ref := &ffi.FileSystemRef{}
+
+	t.Run("GetReparsePointForSymlinkRelative", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("symlink.txt"),
+			virtual.ShareMaskRead,
+			(&virtual.Attributes{}),
+			&virtual.OpenExistingOptions{},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeSymlink)
+			out.SetInodeNumber(800)
+			out.SetPermissions(virtual.PermissionsRead)
+			out.SetLinkCount(1)
+			return symlink, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Open(ref, "\\symlink.txt", dispositionToOptions(windows.FILE_OPEN_IF), windows.FILE_READ_DATA, &info)
+		require.NoError(t, err)
+
+		target := []byte("relative_target.txt")
+		symlink.EXPECT().VirtualReadlink(gomock.Any()).Return(target, virtual.StatusOK)
+
+		buffer := make([]byte, 1024)
+		bytesWritten, err := fs.GetReparsePoint(ref, handle, "\\symlink.txt", buffer)
+		require.NoError(t, err)
+		require.Greater(t, bytesWritten, 0)
+
+		actualTarget, flags, err := extractSymlinkReparseTarget(buffer[:bytesWritten])
+		require.NoError(t, err)
+		require.Equal(t, "relative_target.txt", string(actualTarget))
+		require.Equal(t, uint32(windowsext.SYMLINK_FLAG_RELATIVE), flags)
+	})
+
+	t.Run("GetReparsePointForSymlinkAbsolute", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("abs_symlink.txt"),
+			virtual.ShareMaskRead,
+			(&virtual.Attributes{}),
+			&virtual.OpenExistingOptions{},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeSymlink)
+			out.SetInodeNumber(801)
+			out.SetPermissions(virtual.PermissionsRead)
+			out.SetLinkCount(1)
+			return symlink, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Open(ref, "\\abs_symlink.txt", dispositionToOptions(windows.FILE_OPEN_IF), windows.FILE_READ_DATA, &info)
+		require.NoError(t, err)
+
+		target := []byte("C:\\absolute\\target.txt")
+		symlink.EXPECT().VirtualReadlink(gomock.Any()).Return(target, virtual.StatusOK)
+
+		buffer := make([]byte, 1024)
+		bytesWritten, err := fs.GetReparsePoint(ref, handle, "\\abs_symlink.txt", buffer)
+		require.NoError(t, err)
+		require.Greater(t, bytesWritten, 0)
+
+		actualTarget, flags, err := extractSymlinkReparseTarget(buffer[:bytesWritten])
+		require.NoError(t, err)
+		require.Equal(t, "C:\\absolute\\target.txt", string(actualTarget))
+		require.Equal(t, uint32(0), flags)
+	})
+
+	t.Run("GetReparsePointForRegularFile", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("regular.txt"),
+			virtual.ShareMaskRead,
+			(&virtual.Attributes{}),
+			&virtual.OpenExistingOptions{},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(802)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			return regularFile, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Open(ref, "\\regular.txt", dispositionToOptions(windows.FILE_OPEN_IF), windows.FILE_READ_DATA, &info)
+		require.NoError(t, err)
+
+		regularFile.EXPECT().VirtualReadlink(gomock.Any()).Return(nil, virtual.StatusErrSymlink)
+
+		buffer := make([]byte, 1024)
+		_, err = fs.GetReparsePoint(ref, handle, "\\regular.txt", buffer)
+		require.Error(t, err)
+		require.Equal(t, windows.STATUS_REPARSE, err)
+	})
+}
+
+func TestWinFSPFileSystemDirectoryCreation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rootDirectory := mock.NewMockVirtualDirectory(ctrl)
+	newDirectory := mock.NewMockVirtualDirectory(ctrl)
+
+	fs := winfsp.NewFileSystem(rootDirectory, false)
+	ref := &ffi.FileSystemRef{}
+
+	t.Run("CreateNewDirectory", func(t *testing.T) {
+		// Simulate creating a new directory
+		rootDirectory.EXPECT().VirtualMkdir(
+			path.MustNewComponent("newdir"),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(name path.Component, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Directory, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeDirectory)
+			out.SetInodeNumber(900)
+			out.SetPermissions(virtual.PermissionsExecute | virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(2)
+			out.SetLastDataModificationTime(time.Unix(4000, 0))
+			return newDirectory, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\newdir",
+			dispositionToOptions(windows.FILE_CREATE)|windows.FILE_DIRECTORY_FILE,
+			windows.FILE_LIST_DIRECTORY,
+			0,
+			nil,
+			0,
+			&info,
+		)
+
+		require.NoError(t, err)
+		require.NotZero(t, handle)
+		require.Equal(t, uint32(windows.FILE_ATTRIBUTE_DIRECTORY), info.FileAttributes)
+		require.Equal(t, uint64(900), info.IndexNumber)
+	})
+
+	t.Run("CreateDirectoryAlreadyExists", func(t *testing.T) {
+		// Try to create a directory that already exists
+		rootDirectory.EXPECT().VirtualMkdir(
+			path.MustNewComponent("existingdir"),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(name path.Component, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Directory, virtual.ChangeInfo, virtual.Status) {
+			return nil, virtual.ChangeInfo{}, virtual.StatusErrExist
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\existingdir",
+			dispositionToOptions(windows.FILE_CREATE)|windows.FILE_DIRECTORY_FILE,
+			windows.FILE_LIST_DIRECTORY,
+			0,
+			nil,
+			0,
+			&info,
+		)
+
+		require.Error(t, err)
+		require.Zero(t, handle)
+	})
+}
+
+func TestWinFSPFileSystemDirectoryRemoval(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rootDirectory := mock.NewMockVirtualDirectory(ctrl)
+	emptyDir := mock.NewMockVirtualDirectory(ctrl)
+
+	fs := winfsp.NewFileSystem(rootDirectory, false)
+	ref := &ffi.FileSystemRef{}
+
+	t.Run("RemoveEmptyDirectory", func(t *testing.T) {
+		// Setup directory lookup
+		rootDirectory.EXPECT().VirtualLookup(
+			gomock.Any(),
+			path.MustNewComponent("emptydir"),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.DirectoryChild, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeDirectory)
+			out.SetInodeNumber(901)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite | virtual.PermissionsExecute)
+			out.SetLinkCount(2)
+			return virtual.DirectoryChild{}.FromDirectory(emptyDir), virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\emptydir",
+			dispositionToOptions(windows.FILE_OPEN)|windows.FILE_DIRECTORY_FILE,
+			windows.FILE_LIST_DIRECTORY,
+			0,
+			nil,
+			0,
+			&info,
+		)
+		require.NoError(t, err)
+
+		// Check if directory is empty (should pass)
+		emptyDir.EXPECT().VirtualReadDir(
+			gomock.Any(),
+			uint64(0),
+			virtual.AttributesMask(0),
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, firstCookie uint64, attributesMask virtual.AttributesMask, reporter virtual.DirectoryEntryReporter) virtual.Status {
+			return virtual.StatusOK // No entries reported = empty directory
+		})
+
+		err = fs.CanDelete(ref, handle, "\\emptydir")
+		require.NoError(t, err)
+
+		rootDirectory.EXPECT().VirtualRemove(
+			path.MustNewComponent("emptydir"),
+			true,
+			false,
+		).Return(virtual.ChangeInfo{}, virtual.StatusOK)
+
+		// Cleanup
+		fs.Cleanup(
+			ref,
+			handle,
+			"\\emptydir",
+			ffi.FspCleanupDelete,
+		)
+		fs.Close(ref, handle)
+	})
+}
+
+func TestWinFSPFileSystemFileRemoval(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rootDirectory := mock.NewMockVirtualDirectory(ctrl)
+	file := mock.NewMockVirtualLeaf(ctrl)
+
+	fs := winfsp.NewFileSystem(rootDirectory, false)
+	ref := &ffi.FileSystemRef{}
+
+	t.Run("RemoveRegularFile", func(t *testing.T) {
+		// Create/open a file for deletion
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("deleteme.txt"),
+			virtual.ShareMaskRead,
+			nil,
+			&virtual.OpenExistingOptions{Truncate: false},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(1000)
+			out.SetSizeBytes(100)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			return file, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\deleteme.txt",
+			dispositionToOptions(windows.FILE_OPEN)|windows.FILE_NON_DIRECTORY_FILE,
+			windows.FILE_READ_DATA,
+			0,
+			nil,
+			0,
+			&info,
+		)
+		require.NoError(t, err)
+
+		err = fs.CanDelete(ref, handle, "\\deleteme.txt")
+		require.NoError(t, err)
+
+		rootDirectory.EXPECT().VirtualRemove(
+			path.MustNewComponent("deleteme.txt"),
+			false,
+			true,
+		).Return(virtual.ChangeInfo{}, virtual.StatusOK)
+		fs.Cleanup(
+			ref,
+			handle,
+			"\\deleteme.txt",
+			ffi.FspCleanupDelete,
+		)
+
+		file.EXPECT().VirtualClose(virtual.ShareMaskRead)
+		fs.Close(ref, handle)
+	})
+}
+
+func TestWinFSPFileSystemGetDirInfoByName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rootDirectory := mock.NewMockVirtualDirectory(ctrl)
+	file := mock.NewMockVirtualLeaf(ctrl)
+
+	fs := winfsp.NewFileSystem(rootDirectory, false)
+	ref := &ffi.FileSystemRef{}
+
+	t.Run("GetDirInfoByNameExistingFile", func(t *testing.T) {
+		// First, get a handle to the root directory
+		rootDirectory.EXPECT().VirtualGetAttributes(
+			gomock.Any(),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).Do(func(ctx context.Context, requested virtual.AttributesMask, attributes *virtual.Attributes) {
+			attributes.SetFileType(filesystem.FileTypeDirectory)
+			attributes.SetInodeNumber(1)
+			attributes.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite | virtual.PermissionsExecute)
+			attributes.SetLinkCount(1)
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\",
+			dispositionToOptions(windows.FILE_OPEN)|windows.FILE_DIRECTORY_FILE,
+			windows.FILE_LIST_DIRECTORY,
+			0,
+			nil,
+			0,
+			&info,
+		)
+		require.NoError(t, err)
+
+		// Mock the VirtualLookup call for the target file
+		rootDirectory.EXPECT().VirtualLookup(
+			gomock.Any(),
+			path.MustNewComponent("testfile.txt"),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.DirectoryChild, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(42)
+			out.SetSizeBytes(100)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			out.SetLastDataModificationTime(time.Unix(1000, 0))
+			return virtual.DirectoryChild{}.FromLeaf(file), virtual.StatusOK
+		})
+
+		var dirInfo ffi.FSP_FSCTL_DIR_INFO
+		err = fs.GetDirInfoByName(ref, handle, "testfile.txt", &dirInfo)
+
+		require.NoError(t, err)
+		require.Equal(t, uint64(42), dirInfo.FileInfo.IndexNumber)
+		require.Equal(t, uint64(100), dirInfo.FileInfo.FileSize)
+		require.Equal(t, uint32(windows.FILE_ATTRIBUTE_NORMAL), dirInfo.FileInfo.FileAttributes)
+	})
+
+	t.Run("GetDirInfoByNameNonExistentFile", func(t *testing.T) {
+		// Get a handle to the root directory
+		rootDirectory.EXPECT().VirtualGetAttributes(
+			gomock.Any(),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).Do(func(ctx context.Context, requested virtual.AttributesMask, attributes *virtual.Attributes) {
+			attributes.SetFileType(filesystem.FileTypeDirectory)
+			attributes.SetInodeNumber(1)
+			attributes.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite | virtual.PermissionsExecute)
+			attributes.SetLinkCount(1)
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\",
+			dispositionToOptions(windows.FILE_OPEN)|windows.FILE_DIRECTORY_FILE,
+			windows.FILE_LIST_DIRECTORY,
+			0,
+			nil,
+			0,
+			&info,
+		)
+		require.NoError(t, err)
+
+		// Mock the VirtualLookup call to return StatusErrNoEnt
+		rootDirectory.EXPECT().VirtualLookup(
+			gomock.Any(),
+			path.MustNewComponent("nonexistent.txt"),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).Return(virtual.DirectoryChild{}, virtual.StatusErrNoEnt)
+
+		var dirInfo ffi.FSP_FSCTL_DIR_INFO
+		err = fs.GetDirInfoByName(ref, handle, "nonexistent.txt", &dirInfo)
+
+		require.Error(t, err)
+		require.Equal(t, windows.STATUS_OBJECT_NAME_NOT_FOUND, err)
+	})
+}
+
+func TestWinFSPFileSystemSetBasicInfo(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rootDirectory := mock.NewMockVirtualDirectory(ctrl)
+	file := mock.NewMockVirtualLeaf(ctrl)
+
+	fs := winfsp.NewFileSystem(rootDirectory, false)
+	ref := &ffi.FileSystemRef{}
+
+	t.Run("SetBasicInfoAttributes", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("testfile.txt"),
+			virtual.ShareMaskWrite,
+			(&virtual.Attributes{}).SetPermissions(virtual.PermissionsExecute|virtual.PermissionsRead|virtual.PermissionsWrite),
+			&virtual.OpenExistingOptions{Truncate: true},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(100)
+			out.SetSizeBytes(50)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			out.SetLastDataModificationTime(time.Unix(1000, 0))
+			return file, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var createInfo ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\testfile.txt",
+			0,
+			windows.FILE_WRITE_DATA,
+			0,
+			nil,
+			0,
+			&createInfo,
+		)
+		require.NoError(t, err)
+
+		// Mock setting read-only attribute
+		file.EXPECT().VirtualSetAttributes(
+			gomock.Any(),
+			gomock.Any(),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, in *virtual.Attributes, attributesMask virtual.AttributesMask, out *virtual.Attributes) virtual.Status {
+			permissions, hasPermissions := in.GetPermissions()
+			require.True(t, hasPermissions)
+			require.Equal(t, virtual.PermissionsRead|virtual.PermissionsExecute, permissions)
+
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(100)
+			out.SetSizeBytes(50)
+			out.SetPermissions(permissions)
+			out.SetLinkCount(1)
+			out.SetLastDataModificationTime(time.Unix(1000, 0))
+			return virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		err = fs.SetBasicInfo(
+			ref,
+			handle,
+			ffi.SetBasicInfoAttributes,
+			windows.FILE_ATTRIBUTE_READONLY,
+			0, 0, 0, 0,
+			&info,
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, uint32(windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_ATTRIBUTE_READONLY), info.FileAttributes)
+	})
+
+	t.Run("SetBasicInfoLastWriteTime", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("timefile.txt"),
+			virtual.ShareMaskWrite,
+			(&virtual.Attributes{}).SetPermissions(virtual.PermissionsExecute|virtual.PermissionsRead|virtual.PermissionsWrite),
+			&virtual.OpenExistingOptions{Truncate: true},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(200)
+			out.SetSizeBytes(25)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			out.SetLastDataModificationTime(time.Unix(1000, 0))
+			return file, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var createInfo ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\timefile.txt",
+			0,
+			windows.FILE_WRITE_DATA,
+			0,
+			nil,
+			0,
+			&createInfo,
+		)
+		require.NoError(t, err)
+
+		// Mock setting last write time
+		newTime := time.Unix(2000, 0)
+
+		file.EXPECT().VirtualSetAttributes(
+			gomock.Any(),
+			gomock.Any(),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, in *virtual.Attributes, attributesMask virtual.AttributesMask, out *virtual.Attributes) virtual.Status {
+			require.True(t, attributesMask&virtual.AttributesMaskLastDataModificationTime != 0)
+
+			modTime, hasModTime := in.GetLastDataModificationTime()
+			require.True(t, hasModTime)
+			require.Equal(t, newTime.Unix(), modTime.Unix())
+
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(200)
+			out.SetSizeBytes(25)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			out.SetLastDataModificationTime(modTime)
+			return virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		err = fs.SetBasicInfo(
+			ref,
+			handle,
+			ffi.SetBasicInfoLastWriteTime,
+			0,
+			0, 0, filetime.Timestamp(newTime), 0,
+			&info,
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, filetime.Timestamp(newTime), info.LastWriteTime)
+	})
+}
+
+func TestWinFSPFileSystemSymlinkCreation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rootDirectory := mock.NewMockVirtualDirectory(ctrl)
+	file := mock.NewMockVirtualLeaf(ctrl)
+	symlink := mock.NewMockVirtualLeaf(ctrl)
+
+	fs := winfsp.NewFileSystem(rootDirectory, false)
+	ref := &ffi.FileSystemRef{}
+
+	// Helper function to create a symlink reparse buffer.
+	createSymlinkReparseBuffer := func(target string, flags uint32) []byte {
+		buffer := make([]byte, 1024)
+		used, err := winfsp.FillSymlinkReparseBuffer(target, flags, buffer)
+		require.NoError(t, err)
+		return buffer[:used]
+	}
+
+	// Symlinks are a bit odd: WinFSP creates symlinks by creating regular
+	// files and then calling SetReparsePoint.
+
+	t.Run("CreateSymlinkUsingSetReparsePoint", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("symlink.txt"),
+			virtual.ShareMaskWrite,
+			(&virtual.Attributes{}).SetPermissions(virtual.PermissionsExecute|virtual.PermissionsRead|virtual.PermissionsWrite),
+			&virtual.OpenExistingOptions{Truncate: true},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(1100)
+			out.SetSizeBytes(0)
+			out.SetPermissions(virtual.PermissionsExecute | virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			return file, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\symlink.txt",
+			0,
+			windows.FILE_WRITE_DATA,
+			0,
+			nil,
+			0,
+			&info,
+		)
+		require.NoError(t, err)
+		require.NotZero(t, handle)
+
+		targetPath := "target.txt"
+		reparseBuffer := createSymlinkReparseBuffer(targetPath, windowsext.SYMLINK_FLAG_RELATIVE)
+
+		rootDirectory.EXPECT().VirtualRemove(
+			path.MustNewComponent("symlink.txt"),
+			true,
+			true,
+		).Return(virtual.ChangeInfo{}, virtual.StatusOK)
+
+		rootDirectory.EXPECT().VirtualSymlink(
+			gomock.Any(),
+			[]byte(targetPath),
+			path.MustNewComponent("symlink.txt"),
+			virtual.AttributesMaskFileType,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, target []byte, name path.Component, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeSymlink)
+			out.SetInodeNumber(1101)
+			out.SetPermissions(virtual.PermissionsRead)
+			out.SetLinkCount(1)
+			return symlink, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		err = fs.SetReparsePoint(ref, handle, "\\symlink.txt", reparseBuffer)
+		require.NoError(t, err)
+	})
+
+	t.Run("CreateSymlinkWithAbsolutePath", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("abs_symlink.txt"),
+			virtual.ShareMaskWrite,
+			(&virtual.Attributes{}).SetPermissions(virtual.PermissionsExecute|virtual.PermissionsRead|virtual.PermissionsWrite),
+			&virtual.OpenExistingOptions{Truncate: true},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(1102)
+			out.SetSizeBytes(0)
+			out.SetPermissions(virtual.PermissionsExecute | virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			return file, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\abs_symlink.txt",
+			0,
+			windows.FILE_WRITE_DATA,
+			0,
+			nil,
+			0,
+			&info,
+		)
+		require.NoError(t, err)
+
+		targetPath := "C:\\absolute\\target.txt"
+		reparseBuffer := createSymlinkReparseBuffer(targetPath, 0)
+
+		rootDirectory.EXPECT().VirtualRemove(
+			path.MustNewComponent("abs_symlink.txt"),
+			true,
+			true,
+		).Return(virtual.ChangeInfo{}, virtual.StatusOK)
+
+		rootDirectory.EXPECT().VirtualSymlink(
+			gomock.Any(),
+			[]byte(targetPath),
+			path.MustNewComponent("abs_symlink.txt"),
+			virtual.AttributesMaskFileType,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, target []byte, name path.Component, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeSymlink)
+			out.SetInodeNumber(1103)
+			out.SetPermissions(virtual.PermissionsRead)
+			out.SetLinkCount(1)
+			return symlink, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		err = fs.SetReparsePoint(ref, handle, "\\abs_symlink.txt", reparseBuffer)
+		require.NoError(t, err)
+	})
+
+	t.Run("SetReparsePointInvalidBuffer", func(t *testing.T) {
+		// Test with an buffer that's too small.
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("invalid_symlink.txt"),
+			virtual.ShareMaskWrite,
+			(&virtual.Attributes{}).SetPermissions(virtual.PermissionsExecute|virtual.PermissionsRead|virtual.PermissionsWrite),
+			&virtual.OpenExistingOptions{Truncate: true},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(1104)
+			out.SetSizeBytes(0)
+			out.SetPermissions(virtual.PermissionsExecute | virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			return file, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\invalid_symlink.txt",
+			0,
+			windows.FILE_WRITE_DATA,
+			0,
+			nil,
+			0,
+			&info,
+		)
+		require.NoError(t, err)
+
+		smallBuffer := make([]byte, 4)
+
+		err = fs.SetReparsePoint(ref, handle, "\\invalid_symlink.txt", smallBuffer)
+		require.Error(t, err)
+		require.Equal(t, windows.STATUS_INVALID_PARAMETER, err)
+	})
+
+	t.Run("SetReparsePointUnsupportedTag", func(t *testing.T) {
+		// Test with an unsupported reparse tag.
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("unsupported_reparse.txt"),
+			virtual.ShareMaskWrite,
+			(&virtual.Attributes{}).SetPermissions(virtual.PermissionsExecute|virtual.PermissionsRead|virtual.PermissionsWrite),
+			&virtual.OpenExistingOptions{Truncate: true},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(1105)
+			out.SetSizeBytes(0)
+			out.SetPermissions(virtual.PermissionsExecute | virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			return file, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\unsupported_reparse.txt",
+			0,
+			windows.FILE_WRITE_DATA,
+			0,
+			nil,
+			0,
+			&info,
+		)
+		require.NoError(t, err)
+
+		buffer := make([]byte, int(unsafe.Sizeof(windowsext.REPARSE_DATA_BUFFER{})))
+		rdb := (*windowsext.REPARSE_DATA_BUFFER)(unsafe.Pointer(&buffer[0]))
+		rdb.ReparseTag = 0x12345678
+		rdb.ReparseDataLength = 0
+		rdb.Reserved = 0
+
+		err = fs.SetReparsePoint(ref, handle, "\\unsupported_reparse.txt", buffer)
+		require.Error(t, err)
+		require.Equal(t, windows.STATUS_IO_REPARSE_TAG_MISMATCH, err)
+	})
+}
+
+func TestWinFSPFileSystemGetSecurity(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rootDirectory := mock.NewMockVirtualDirectory(ctrl)
+	file := mock.NewMockVirtualLeaf(ctrl)
+
+	fs := winfsp.NewFileSystem(rootDirectory, false)
+	ref := &ffi.FileSystemRef{}
+
+	t.Run("GetSecurityForFile", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("security_test.txt"),
+			virtual.ShareMaskRead,
+			(&virtual.Attributes{}).SetPermissions(virtual.PermissionsExecute|virtual.PermissionsRead|virtual.PermissionsWrite),
+			&virtual.OpenExistingOptions{Truncate: true},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(1200)
+			out.SetSizeBytes(100)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			out.SetLinkCount(1)
+			return file, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var createInfo ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\security_test.txt",
+			0,
+			windows.FILE_READ_DATA,
+			0,
+			nil,
+			0,
+			&createInfo,
+		)
+		require.NoError(t, err)
+
+		file.EXPECT().VirtualGetAttributes(
+			gomock.Any(),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).Do(func(ctx context.Context, requested virtual.AttributesMask, attributes *virtual.Attributes) {
+			attributes.SetFileType(filesystem.FileTypeRegularFile)
+			attributes.SetInodeNumber(1200)
+			attributes.SetSizeBytes(100)
+			attributes.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite)
+			attributes.SetLinkCount(1)
+		})
+
+		sd, err := fs.GetSecurity(ref, handle)
+		require.NoError(t, err)
+		require.NotNil(t, sd)
+		dacl, err := getAclEntries(sd)
+		require.NoError(t, err)
+		require.Len(t, dacl, 2)
+		require.Equal(t, uint8(windows.ACCESS_ALLOWED_ACE_TYPE), dacl[0].Header.AceType)
+		require.Equal(t, windows.ACCESS_MASK(0x1f01bf), dacl[0].Mask)
+		require.Equal(t, uint8(windows.ACCESS_ALLOWED_ACE_TYPE), dacl[1].Header.AceType)
+		require.Equal(t, windows.ACCESS_MASK(0x1201bf), dacl[1].Mask)
+	})
+
+	t.Run("GetSecurityForDirectory", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualGetAttributes(
+			gomock.Any(),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).Do(func(ctx context.Context, requested virtual.AttributesMask, attributes *virtual.Attributes) {
+			attributes.SetFileType(filesystem.FileTypeDirectory)
+			attributes.SetInodeNumber(1)
+			attributes.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite | virtual.PermissionsExecute)
+			attributes.SetLinkCount(2)
+		})
+
+		var info ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\",
+			dispositionToOptions(windows.FILE_OPEN)|windows.FILE_DIRECTORY_FILE,
+			windows.FILE_LIST_DIRECTORY,
+			0,
+			nil,
+			0,
+			&info,
+		)
+		require.NoError(t, err)
+
+		rootDirectory.EXPECT().VirtualGetAttributes(
+			gomock.Any(),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).Do(func(ctx context.Context, requested virtual.AttributesMask, attributes *virtual.Attributes) {
+			attributes.SetFileType(filesystem.FileTypeDirectory)
+			attributes.SetInodeNumber(1)
+			attributes.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite | virtual.PermissionsExecute)
+			attributes.SetLinkCount(2)
+		})
+
+		sd, err := fs.GetSecurity(ref, handle)
+		require.NoError(t, err)
+		dacl, err := getAclEntries(sd)
+		require.NoError(t, err)
+		require.Len(t, dacl, 2)
+		require.Equal(t, uint8(windows.ACCESS_ALLOWED_ACE_TYPE), dacl[0].Header.AceType)
+		require.Equal(t, windows.ACCESS_MASK(0x1f01ff), dacl[0].Mask)
+		require.Equal(t, uint8(windows.ACCESS_ALLOWED_ACE_TYPE), dacl[1].Header.AceType)
+		require.Equal(t, windows.ACCESS_MASK(0x1201ff), dacl[1].Mask)
+	})
+
+	t.Run("GetSecurityForReadOnlyFile", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualOpenChild(
+			gomock.Any(),
+			path.MustNewComponent("readonly.txt"),
+			virtual.ShareMaskRead,
+			(&virtual.Attributes{}).SetPermissions(virtual.PermissionsExecute|virtual.PermissionsRead|virtual.PermissionsWrite),
+			&virtual.OpenExistingOptions{Truncate: true},
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, shareAccess virtual.ShareMask, createAttributes *virtual.Attributes, existingOptions *virtual.OpenExistingOptions, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.Leaf, virtual.AttributesMask, virtual.ChangeInfo, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(1201)
+			out.SetSizeBytes(50)
+			out.SetPermissions(virtual.PermissionsRead)
+			out.SetLinkCount(1)
+			return file, 0, virtual.ChangeInfo{}, virtual.StatusOK
+		})
+
+		var createInfo ffi.FSP_FSCTL_FILE_INFO
+		handle, err := fs.Create(
+			ref,
+			"\\readonly.txt",
+			0,
+			windows.FILE_READ_DATA,
+			0,
+			nil,
+			0,
+			&createInfo,
+		)
+		require.NoError(t, err)
+
+		file.EXPECT().VirtualGetAttributes(
+			gomock.Any(),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).Do(func(ctx context.Context, requested virtual.AttributesMask, attributes *virtual.Attributes) {
+			attributes.SetFileType(filesystem.FileTypeRegularFile)
+			attributes.SetInodeNumber(1201)
+			attributes.SetSizeBytes(50)
+			attributes.SetPermissions(virtual.PermissionsRead)
+			attributes.SetLinkCount(1)
+		})
+
+		sd, err := fs.GetSecurity(ref, handle)
+		require.NoError(t, err)
+		dacl, err := getAclEntries(sd)
+		require.NoError(t, err)
+		require.Len(t, dacl, 2)
+		require.Equal(t, uint8(windows.ACCESS_ALLOWED_ACE_TYPE), dacl[0].Header.AceType)
+		require.Equal(t, windows.ACCESS_MASK(0x1f01b9), dacl[0].Mask)
+		require.Equal(t, uint8(windows.ACCESS_ALLOWED_ACE_TYPE), dacl[1].Header.AceType)
+		require.Equal(t, windows.ACCESS_MASK(0x1200a9), dacl[1].Mask)
+	})
+}
+
+func TestWinFSPFileSystemGetSecurityByName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rootDirectory := mock.NewMockVirtualDirectory(ctrl)
+	file := mock.NewMockVirtualLeaf(ctrl)
+
+	fs := winfsp.NewFileSystem(rootDirectory, false)
+	ref := &ffi.FileSystemRef{}
+
+	t.Run("GetSecurityByNameForFile", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualLookup(
+			gomock.Any(),
+			path.MustNewComponent("security_by_name.txt"),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.DirectoryChild, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(1300)
+			out.SetSizeBytes(200)
+			out.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite | virtual.PermissionsExecute)
+			out.SetLinkCount(1)
+			return virtual.DirectoryChild{}.FromLeaf(file), virtual.StatusOK
+		})
+
+		fa, sd, err := fs.GetSecurityByName(
+			ref,
+			"\\security_by_name.txt",
+			ffi.GetSecurityByName,
+		)
+		require.NoError(t, err)
+		require.Equal(t, uint32(windows.FILE_ATTRIBUTE_NORMAL), fa)
+		require.NotNil(t, sd)
+		dacl, err := getAclEntries(sd)
+		require.NoError(t, err)
+		require.Len(t, dacl, 2)
+		require.Equal(t, uint8(windows.ACCESS_ALLOWED_ACE_TYPE), dacl[0].Header.AceType)
+		require.Equal(t, windows.ACCESS_MASK(0x1f01bf), dacl[0].Mask)
+		require.Equal(t, uint8(windows.ACCESS_ALLOWED_ACE_TYPE), dacl[1].Header.AceType)
+		require.Equal(t, windows.ACCESS_MASK(0x1201bf), dacl[1].Mask)
+	})
+
+	t.Run("GetSecurityByNameForRootDirectory", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualGetAttributes(
+			gomock.Any(),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).Do(func(ctx context.Context, requested virtual.AttributesMask, attributes *virtual.Attributes) {
+			attributes.SetFileType(filesystem.FileTypeDirectory)
+			attributes.SetInodeNumber(1)
+			attributes.SetPermissions(virtual.PermissionsRead | virtual.PermissionsWrite | virtual.PermissionsExecute)
+			attributes.SetLinkCount(2)
+		})
+
+		fa, sd, err := fs.GetSecurityByName(
+			ref,
+			"\\",
+			ffi.GetSecurityByName,
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, uint32(windows.FILE_ATTRIBUTE_DIRECTORY), fa)
+		require.NotNil(t, sd)
+		dacl, err := getAclEntries(sd)
+		require.NoError(t, err)
+		require.Len(t, dacl, 2)
+		require.Equal(t, uint8(windows.ACCESS_ALLOWED_ACE_TYPE), dacl[0].Header.AceType)
+		require.Equal(t, windows.ACCESS_MASK(0x1f01ff), dacl[0].Mask)
+		require.Equal(t, uint8(windows.ACCESS_ALLOWED_ACE_TYPE), dacl[1].Header.AceType)
+		require.Equal(t, windows.ACCESS_MASK(0x1201ff), dacl[1].Mask)
+	})
+
+	t.Run("GetSecurityByNameExistenceOnly", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualLookup(
+			gomock.Any(),
+			path.MustNewComponent("exists.txt"),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.DirectoryChild, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(1301)
+			out.SetSizeBytes(150)
+			out.SetPermissions(virtual.PermissionsRead)
+			out.SetLinkCount(1)
+			return virtual.DirectoryChild{}.FromLeaf(file), virtual.StatusOK
+		})
+
+		fileAttributes, securityDescriptor, err := fs.GetSecurityByName(
+			ref,
+			"\\exists.txt",
+			ffi.GetExistenceOnly,
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, uint32(0), fileAttributes)
+		require.Nil(t, securityDescriptor)
+	})
+
+	t.Run("GetSecurityByNameForReadOnlyFile", func(t *testing.T) {
+		rootDirectory.EXPECT().VirtualLookup(
+			gomock.Any(),
+			path.MustNewComponent("readonly_by_name.txt"),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.DirectoryChild, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeRegularFile)
+			out.SetInodeNumber(1302)
+			out.SetSizeBytes(75)
+			out.SetPermissions(virtual.PermissionsRead)
+			out.SetLinkCount(1)
+			return virtual.DirectoryChild{}.FromLeaf(file), virtual.StatusOK
+		})
+
+		fileAttributes, securityDescriptor, err := fs.GetSecurityByName(
+			ref,
+			"\\readonly_by_name.txt",
+			ffi.GetSecurityByName,
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, uint32(windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_ATTRIBUTE_READONLY), fileAttributes)
+		require.NotNil(t, securityDescriptor)
+	})
+
+	t.Run("GetSecurityByNameForSymlink", func(t *testing.T) {
+		// Test for a symlink
+		rootDirectory.EXPECT().VirtualLookup(
+			gomock.Any(),
+			path.MustNewComponent("symlink_by_name.txt"),
+			winfsp.AttributesMaskForWinFSPAttr,
+			gomock.Any(),
+		).DoAndReturn(func(ctx context.Context, name path.Component, requested virtual.AttributesMask, out *virtual.Attributes) (virtual.DirectoryChild, virtual.Status) {
+			out.SetFileType(filesystem.FileTypeSymlink)
+			out.SetInodeNumber(1303)
+			out.SetPermissions(virtual.PermissionsRead)
+			out.SetLinkCount(1)
+			return virtual.DirectoryChild{}.FromLeaf(file), virtual.StatusOK
+		})
+
+		fileAttributes, securityDescriptor, err := fs.GetSecurityByName(
+			ref,
+			"\\symlink_by_name.txt",
+			ffi.GetSecurityByName,
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, uint32(windows.FILE_ATTRIBUTE_REPARSE_POINT|windows.FILE_ATTRIBUTE_READONLY), fileAttributes)
+		require.NotNil(t, securityDescriptor)
+	})
+}
+
+// There are no unit tests for SetSecurity as that requires WinFSP to be
+// installed for several functions such as
+// PosixMapSecurityDescriptorToPermissions. We test this in the
+// integration tests instead.

--- a/pkg/filesystem/virtual/winfsp/opened_files_pool.go
+++ b/pkg/filesystem/virtual/winfsp/opened_files_pool.go
@@ -1,0 +1,103 @@
+//go:build windows
+// +build windows
+
+package winfsp
+
+import (
+	"sync"
+
+	"github.com/buildbarn/bb-remote-execution/pkg/filesystem/virtual"
+	path "github.com/buildbarn/bb-storage/pkg/filesystem/path"
+
+	"golang.org/x/sys/windows"
+)
+
+// openedNodesPool holds the state of nodes that are opened by WinFSP.
+type openedNodesPool struct {
+	nodeLock   sync.Mutex
+	handles    map[uintptr]*openedNode
+	nextHandle uintptr
+}
+
+type openedNode struct {
+	name      path.Component
+	parent    virtual.Directory
+	node      virtual.DirectoryChild
+	shareMask virtual.ShareMask
+}
+
+func newOpenedNodesPool() openedNodesPool {
+	return openedNodesPool{
+		handles:    make(map[uintptr]*openedNode),
+		nextHandle: 1,
+	}
+}
+
+func (ofp *openedNodesPool) nodeForHandle(handle uintptr) (virtual.DirectoryChild, error) {
+	ofp.nodeLock.Lock()
+	defer ofp.nodeLock.Unlock()
+	node, ok := ofp.handles[handle]
+	if !ok {
+		return virtual.DirectoryChild{}, windows.STATUS_INVALID_HANDLE
+	}
+	return node.node, nil
+}
+
+func (ofp *openedNodesPool) nodeForDirectoryHandle(handle uintptr) (virtual.Directory, error) {
+	child, err := ofp.nodeForHandle(handle)
+	if err != nil {
+		return nil, err
+	}
+	dir, _ := child.GetPair()
+	if dir == nil {
+		return nil, windows.STATUS_NOT_A_DIRECTORY
+	}
+	return dir, nil
+}
+
+func (ofp *openedNodesPool) nodeForLeafHandle(handle uintptr) (virtual.Leaf, error) {
+	child, err := ofp.nodeForHandle(handle)
+	if err != nil {
+		return nil, err
+	}
+	_, leaf := child.GetPair()
+	if leaf == nil {
+		return nil, windows.STATUS_FILE_IS_A_DIRECTORY
+	}
+	return leaf, nil
+}
+
+func (ofp *openedNodesPool) trackedNodeForHandle(handle uintptr) (*openedNode, error) {
+	ofp.nodeLock.Lock()
+	defer ofp.nodeLock.Unlock()
+	node, ok := ofp.handles[handle]
+	if !ok {
+		return nil, windows.STATUS_INVALID_HANDLE
+	}
+	return node, nil
+}
+
+func (ofp *openedNodesPool) createHandle(parent virtual.Directory, name path.Component, node virtual.DirectoryChild, shareMask virtual.ShareMask) uintptr {
+	ofp.nodeLock.Lock()
+	defer ofp.nodeLock.Unlock()
+	handle := ofp.nextHandle
+	ofp.nextHandle++
+	ofp.handles[handle] = &openedNode{
+		parent:    parent,
+		name:      name,
+		node:      node,
+		shareMask: shareMask,
+	}
+	return handle
+}
+
+func (ofp *openedNodesPool) removeHandle(handle uintptr) (*openedNode, error) {
+	ofp.nodeLock.Lock()
+	defer ofp.nodeLock.Unlock()
+	node, ok := ofp.handles[handle]
+	if !ok {
+		return nil, windows.STATUS_INVALID_HANDLE
+	}
+	delete(ofp.handles, handle)
+	return node, nil
+}

--- a/pkg/proto/configuration/bb_worker/bb_worker.pb.go
+++ b/pkg/proto/configuration/bb_worker/bb_worker.pb.go
@@ -352,6 +352,7 @@ type VirtualBuildDirectoryConfiguration struct {
 	ShuffleDirectoryListings            bool                        `protobuf:"varint,3,opt,name=shuffle_directory_listings,json=shuffleDirectoryListings,proto3" json:"shuffle_directory_listings,omitempty"`
 	HiddenFilesPattern                  string                      `protobuf:"bytes,4,opt,name=hidden_files_pattern,json=hiddenFilesPattern,proto3" json:"hidden_files_pattern,omitempty"`
 	MaximumWritableFileUploadDelay      *durationpb.Duration        `protobuf:"bytes,5,opt,name=maximum_writable_file_upload_delay,json=maximumWritableFileUploadDelay,proto3" json:"maximum_writable_file_upload_delay,omitempty"`
+	CaseInsensitive                     bool                        `protobuf:"varint,6,opt,name=case_insensitive,json=caseInsensitive,proto3" json:"case_insensitive,omitempty"`
 	unknownFields                       protoimpl.UnknownFields
 	sizeCache                           protoimpl.SizeCache
 }
@@ -419,6 +420,13 @@ func (x *VirtualBuildDirectoryConfiguration) GetMaximumWritableFileUploadDelay()
 		return x.MaximumWritableFileUploadDelay
 	}
 	return nil
+}
+
+func (x *VirtualBuildDirectoryConfiguration) GetCaseInsensitive() bool {
+	if x != nil {
+		return x.CaseInsensitive
+	}
+	return false
 }
 
 type RunnerConfiguration struct {
@@ -705,13 +713,14 @@ const file_pkg_proto_configuration_bb_worker_bb_worker_proto_rawDesc = "" +
 	"\x14cache_directory_path\x18\x02 \x01(\tR\x12cacheDirectoryPath\x127\n" +
 	"\x18maximum_cache_file_count\x18\x03 \x01(\x04R\x15maximumCacheFileCount\x127\n" +
 	"\x18maximum_cache_size_bytes\x18\x04 \x01(\x03R\x15maximumCacheSizeBytes\x12r\n" +
-	"\x18cache_replacement_policy\x18\x05 \x01(\x0e28.buildbarn.configuration.eviction.CacheReplacementPolicyR\x16cacheReplacementPolicy\"\xc1\x03\n" +
+	"\x18cache_replacement_policy\x18\x05 \x01(\x0e28.buildbarn.configuration.eviction.CacheReplacementPolicyR\x16cacheReplacementPolicy\"\xec\x03\n" +
 	"\"VirtualBuildDirectoryConfiguration\x12T\n" +
 	"\x05mount\x18\x01 \x01(\v2>.buildbarn.configuration.filesystem.virtual.MountConfigurationR\x05mount\x12n\n" +
 	"&maximum_execution_timeout_compensation\x18\x02 \x01(\v2\x19.google.protobuf.DurationR#maximumExecutionTimeoutCompensation\x12<\n" +
 	"\x1ashuffle_directory_listings\x18\x03 \x01(\bR\x18shuffleDirectoryListings\x120\n" +
 	"\x14hidden_files_pattern\x18\x04 \x01(\tR\x12hiddenFilesPattern\x12e\n" +
-	"\"maximum_writable_file_upload_delay\x18\x05 \x01(\v2\x19.google.protobuf.DurationR\x1emaximumWritableFileUploadDelay\"\xbe\t\n" +
+	"\"maximum_writable_file_upload_delay\x18\x05 \x01(\v2\x19.google.protobuf.DurationR\x1emaximumWritableFileUploadDelay\x12)\n" +
+	"\x10case_insensitive\x18\x06 \x01(\bR\x0fcaseInsensitive\"\xbe\t\n" +
 	"\x13RunnerConfiguration\x12M\n" +
 	"\bendpoint\x18\x01 \x01(\v21.buildbarn.configuration.grpc.ClientConfigurationR\bendpoint\x12 \n" +
 	"\vconcurrency\x18\x02 \x01(\x04R\vconcurrency\x120\n" +

--- a/pkg/proto/configuration/bb_worker/bb_worker.proto
+++ b/pkg/proto/configuration/bb_worker/bb_worker.proto
@@ -294,6 +294,11 @@ message VirtualBuildDirectoryConfiguration {
   //
   // Recommended value: 60s.
   google.protobuf.Duration maximum_writable_file_upload_delay = 5;
+
+  // Whether the file system should be case insensitive. Note that
+  // bazel on Windows effectively assumes that the file system is case
+  // insensitive, so make sure this is set to true when using the WinFSP.
+  bool case_insensitive = 6;
 }
 
 message RunnerConfiguration {

--- a/pkg/proto/configuration/filesystem/virtual/BUILD.bazel
+++ b/pkg/proto/configuration/filesystem/virtual/BUILD.bazel
@@ -10,6 +10,7 @@ proto_library(
         "@com_github_buildbarn_bb_storage//pkg/proto/configuration/eviction:eviction_proto",
         "@com_github_buildbarn_bb_storage//pkg/proto/configuration/jmespath:jmespath_proto",
         "@protobuf//:duration_proto",
+        "@protobuf//:empty_proto",
         "@protobuf//:wrappers_proto",
     ],
 )

--- a/pkg/proto/configuration/filesystem/virtual/virtual.pb.go
+++ b/pkg/proto/configuration/filesystem/virtual/virtual.pb.go
@@ -12,6 +12,7 @@ import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
+	emptypb "google.golang.org/protobuf/types/known/emptypb"
 	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 	reflect "reflect"
 	sync "sync"
@@ -81,6 +82,7 @@ type MountConfiguration struct {
 	//
 	//	*MountConfiguration_Fuse
 	//	*MountConfiguration_Nfsv4
+	//	*MountConfiguration_Winfsp
 	Backend       isMountConfiguration_Backend `protobuf_oneof:"backend"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -148,6 +150,15 @@ func (x *MountConfiguration) GetNfsv4() *NFSv4MountConfiguration {
 	return nil
 }
 
+func (x *MountConfiguration) GetWinfsp() *emptypb.Empty {
+	if x != nil {
+		if x, ok := x.Backend.(*MountConfiguration_Winfsp); ok {
+			return x.Winfsp
+		}
+	}
+	return nil
+}
+
 type isMountConfiguration_Backend interface {
 	isMountConfiguration_Backend()
 }
@@ -160,9 +171,15 @@ type MountConfiguration_Nfsv4 struct {
 	Nfsv4 *NFSv4MountConfiguration `protobuf:"bytes,3,opt,name=nfsv4,proto3,oneof"`
 }
 
+type MountConfiguration_Winfsp struct {
+	Winfsp *emptypb.Empty `protobuf:"bytes,4,opt,name=winfsp,proto3,oneof"`
+}
+
 func (*MountConfiguration_Fuse) isMountConfiguration_Backend() {}
 
 func (*MountConfiguration_Nfsv4) isMountConfiguration_Backend() {}
+
+func (*MountConfiguration_Winfsp) isMountConfiguration_Backend() {}
 
 type FUSEMountConfiguration struct {
 	state                                            protoimpl.MessageState             `protogen:"open.v1"`
@@ -522,12 +539,13 @@ var File_pkg_proto_configuration_filesystem_virtual_virtual_proto protoreflect.F
 
 const file_pkg_proto_configuration_filesystem_virtual_virtual_proto_rawDesc = "" +
 	"\n" +
-	"8pkg/proto/configuration/filesystem/virtual/virtual.proto\x12*buildbarn.configuration.filesystem.virtual\x1a\x1egoogle/protobuf/duration.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a/pkg/proto/configuration/eviction/eviction.proto\x1a/pkg/proto/configuration/jmespath/jmespath.proto\"\xf5\x01\n" +
+	"8pkg/proto/configuration/filesystem/virtual/virtual.proto\x12*buildbarn.configuration.filesystem.virtual\x1a\x1egoogle/protobuf/duration.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a/pkg/proto/configuration/eviction/eviction.proto\x1a/pkg/proto/configuration/jmespath/jmespath.proto\"\xa7\x02\n" +
 	"\x12MountConfiguration\x12\x1d\n" +
 	"\n" +
 	"mount_path\x18\x01 \x01(\tR\tmountPath\x12X\n" +
 	"\x04fuse\x18\x02 \x01(\v2B.buildbarn.configuration.filesystem.virtual.FUSEMountConfigurationH\x00R\x04fuse\x12[\n" +
-	"\x05nfsv4\x18\x03 \x01(\v2C.buildbarn.configuration.filesystem.virtual.NFSv4MountConfigurationH\x00R\x05nfsv4B\t\n" +
+	"\x05nfsv4\x18\x03 \x01(\v2C.buildbarn.configuration.filesystem.virtual.NFSv4MountConfigurationH\x00R\x05nfsv4\x120\n" +
+	"\x06winfsp\x18\x04 \x01(\v2\x16.google.protobuf.EmptyH\x00R\x06winfspB\t\n" +
 	"\abackend\"\xca\x06\n" +
 	"\x16FUSEMountConfiguration\x12S\n" +
 	"\x18directory_entry_validity\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x16directoryEntryValidity\x12S\n" +
@@ -589,32 +607,34 @@ var file_pkg_proto_configuration_filesystem_virtual_virtual_proto_goTypes = []an
 	(*NFSv4LinuxMountConfiguration)(nil),           // 5: buildbarn.configuration.filesystem.virtual.NFSv4LinuxMountConfiguration
 	(*RPCv2SystemAuthenticationConfiguration)(nil), // 6: buildbarn.configuration.filesystem.virtual.RPCv2SystemAuthenticationConfiguration
 	nil,                                  // 7: buildbarn.configuration.filesystem.virtual.FUSEMountConfiguration.LinuxBackingDevInfoTunablesEntry
-	(*durationpb.Duration)(nil),          // 8: google.protobuf.Duration
-	(*jmespath.Expression)(nil),          // 9: buildbarn.configuration.jmespath.Expression
-	(*wrapperspb.UInt32Value)(nil),       // 10: google.protobuf.UInt32Value
-	(eviction.CacheReplacementPolicy)(0), // 11: buildbarn.configuration.eviction.CacheReplacementPolicy
+	(*emptypb.Empty)(nil),                // 8: google.protobuf.Empty
+	(*durationpb.Duration)(nil),          // 9: google.protobuf.Duration
+	(*jmespath.Expression)(nil),          // 10: buildbarn.configuration.jmespath.Expression
+	(*wrapperspb.UInt32Value)(nil),       // 11: google.protobuf.UInt32Value
+	(eviction.CacheReplacementPolicy)(0), // 12: buildbarn.configuration.eviction.CacheReplacementPolicy
 }
 var file_pkg_proto_configuration_filesystem_virtual_virtual_proto_depIdxs = []int32{
 	2,  // 0: buildbarn.configuration.filesystem.virtual.MountConfiguration.fuse:type_name -> buildbarn.configuration.filesystem.virtual.FUSEMountConfiguration
 	3,  // 1: buildbarn.configuration.filesystem.virtual.MountConfiguration.nfsv4:type_name -> buildbarn.configuration.filesystem.virtual.NFSv4MountConfiguration
-	8,  // 2: buildbarn.configuration.filesystem.virtual.FUSEMountConfiguration.directory_entry_validity:type_name -> google.protobuf.Duration
-	8,  // 3: buildbarn.configuration.filesystem.virtual.FUSEMountConfiguration.inode_attribute_validity:type_name -> google.protobuf.Duration
-	9,  // 4: buildbarn.configuration.filesystem.virtual.FUSEMountConfiguration.in_header_authentication_metadata_jmespath_expression:type_name -> buildbarn.configuration.jmespath.Expression
-	7,  // 5: buildbarn.configuration.filesystem.virtual.FUSEMountConfiguration.linux_backing_dev_info_tunables:type_name -> buildbarn.configuration.filesystem.virtual.FUSEMountConfiguration.LinuxBackingDevInfoTunablesEntry
-	0,  // 6: buildbarn.configuration.filesystem.virtual.FUSEMountConfiguration.mount_method:type_name -> buildbarn.configuration.filesystem.virtual.FUSEMountConfiguration.MountMethod
-	4,  // 7: buildbarn.configuration.filesystem.virtual.NFSv4MountConfiguration.darwin:type_name -> buildbarn.configuration.filesystem.virtual.NFSv4DarwinMountConfiguration
-	5,  // 8: buildbarn.configuration.filesystem.virtual.NFSv4MountConfiguration.linux:type_name -> buildbarn.configuration.filesystem.virtual.NFSv4LinuxMountConfiguration
-	8,  // 9: buildbarn.configuration.filesystem.virtual.NFSv4MountConfiguration.enforced_lease_time:type_name -> google.protobuf.Duration
-	8,  // 10: buildbarn.configuration.filesystem.virtual.NFSv4MountConfiguration.announced_lease_time:type_name -> google.protobuf.Duration
-	6,  // 11: buildbarn.configuration.filesystem.virtual.NFSv4MountConfiguration.system_authentication:type_name -> buildbarn.configuration.filesystem.virtual.RPCv2SystemAuthenticationConfiguration
-	10, // 12: buildbarn.configuration.filesystem.virtual.NFSv4DarwinMountConfiguration.minor_version:type_name -> google.protobuf.UInt32Value
-	9,  // 13: buildbarn.configuration.filesystem.virtual.RPCv2SystemAuthenticationConfiguration.metadata_jmespath_expression:type_name -> buildbarn.configuration.jmespath.Expression
-	11, // 14: buildbarn.configuration.filesystem.virtual.RPCv2SystemAuthenticationConfiguration.cache_replacement_policy:type_name -> buildbarn.configuration.eviction.CacheReplacementPolicy
-	15, // [15:15] is the sub-list for method output_type
-	15, // [15:15] is the sub-list for method input_type
-	15, // [15:15] is the sub-list for extension type_name
-	15, // [15:15] is the sub-list for extension extendee
-	0,  // [0:15] is the sub-list for field type_name
+	8,  // 2: buildbarn.configuration.filesystem.virtual.MountConfiguration.winfsp:type_name -> google.protobuf.Empty
+	9,  // 3: buildbarn.configuration.filesystem.virtual.FUSEMountConfiguration.directory_entry_validity:type_name -> google.protobuf.Duration
+	9,  // 4: buildbarn.configuration.filesystem.virtual.FUSEMountConfiguration.inode_attribute_validity:type_name -> google.protobuf.Duration
+	10, // 5: buildbarn.configuration.filesystem.virtual.FUSEMountConfiguration.in_header_authentication_metadata_jmespath_expression:type_name -> buildbarn.configuration.jmespath.Expression
+	7,  // 6: buildbarn.configuration.filesystem.virtual.FUSEMountConfiguration.linux_backing_dev_info_tunables:type_name -> buildbarn.configuration.filesystem.virtual.FUSEMountConfiguration.LinuxBackingDevInfoTunablesEntry
+	0,  // 7: buildbarn.configuration.filesystem.virtual.FUSEMountConfiguration.mount_method:type_name -> buildbarn.configuration.filesystem.virtual.FUSEMountConfiguration.MountMethod
+	4,  // 8: buildbarn.configuration.filesystem.virtual.NFSv4MountConfiguration.darwin:type_name -> buildbarn.configuration.filesystem.virtual.NFSv4DarwinMountConfiguration
+	5,  // 9: buildbarn.configuration.filesystem.virtual.NFSv4MountConfiguration.linux:type_name -> buildbarn.configuration.filesystem.virtual.NFSv4LinuxMountConfiguration
+	9,  // 10: buildbarn.configuration.filesystem.virtual.NFSv4MountConfiguration.enforced_lease_time:type_name -> google.protobuf.Duration
+	9,  // 11: buildbarn.configuration.filesystem.virtual.NFSv4MountConfiguration.announced_lease_time:type_name -> google.protobuf.Duration
+	6,  // 12: buildbarn.configuration.filesystem.virtual.NFSv4MountConfiguration.system_authentication:type_name -> buildbarn.configuration.filesystem.virtual.RPCv2SystemAuthenticationConfiguration
+	11, // 13: buildbarn.configuration.filesystem.virtual.NFSv4DarwinMountConfiguration.minor_version:type_name -> google.protobuf.UInt32Value
+	10, // 14: buildbarn.configuration.filesystem.virtual.RPCv2SystemAuthenticationConfiguration.metadata_jmespath_expression:type_name -> buildbarn.configuration.jmespath.Expression
+	12, // 15: buildbarn.configuration.filesystem.virtual.RPCv2SystemAuthenticationConfiguration.cache_replacement_policy:type_name -> buildbarn.configuration.eviction.CacheReplacementPolicy
+	16, // [16:16] is the sub-list for method output_type
+	16, // [16:16] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_pkg_proto_configuration_filesystem_virtual_virtual_proto_init() }
@@ -625,6 +645,7 @@ func file_pkg_proto_configuration_filesystem_virtual_virtual_proto_init() {
 	file_pkg_proto_configuration_filesystem_virtual_virtual_proto_msgTypes[0].OneofWrappers = []any{
 		(*MountConfiguration_Fuse)(nil),
 		(*MountConfiguration_Nfsv4)(nil),
+		(*MountConfiguration_Winfsp)(nil),
 	}
 	file_pkg_proto_configuration_filesystem_virtual_virtual_proto_msgTypes[2].OneofWrappers = []any{
 		(*NFSv4MountConfiguration_Darwin)(nil),

--- a/pkg/proto/configuration/filesystem/virtual/virtual.proto
+++ b/pkg/proto/configuration/filesystem/virtual/virtual.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package buildbarn.configuration.filesystem.virtual;
 
 import "google/protobuf/duration.proto";
+import "google/protobuf/empty.proto";
 import "google/protobuf/wrappers.proto";
 import "pkg/proto/configuration/eviction/eviction.proto";
 import "pkg/proto/configuration/jmespath/jmespath.proto";
@@ -36,6 +37,21 @@ message MountConfiguration {
     // NFSv4.1 (RFC 8881). The use of NFSv4.1 is recommended, because it
     // provides better parallelism.
     NFSv4MountConfiguration nfsv4 = 3;
+
+    // Expose a filesystem using WinFSP. This option is only available
+    // on Windows hosts that have WinFSP installed. For example, simply
+    // do `choco install WinFSP`.
+    //
+    // When using the WinFSP VFS it is recommended to create the mount
+    // using MountManager as this avoids odd errors with some Windows
+    // programs, such as https://github.com/winfsp/winfsp/issues/573.
+    // This either requires administrator permissions, or the
+    // `MountUseMountmgrFromFSD` registry key must be set; see
+    // https://github.com/winfsp/winfsp/wiki/WinFsp-Registry-Settings.
+    // Once that's enabled, specify the mount_path as something like
+    // `\\.\\b:`. Note in jsonnet that would be '\\\\.\\b:' to account
+    // for escaping.
+    google.protobuf.Empty winfsp = 4;
   }
 }
 

--- a/tools/github_workflows/github_workflows.jsonnet
+++ b/tools/github_workflows/github_workflows.jsonnet
@@ -17,4 +17,17 @@ workflows_template.getWorkflows(
     'bb_scheduler:bb_scheduler',
     'bb_worker:bb_worker',
   ],
+  [],
+  [
+    {
+      name: 'Install WinFSP',
+      run: 'choco install winfsp',
+      'if': "matrix.host.platform_name == 'windows_amd64'",
+    },
+    {
+      name: 'Execute WinFSP Integration Tests',
+      run: 'bazel test --platforms=@rules_go//go/toolchain:windows_amd64 //pkg/filesystem/virtual/winfsp:file_system_integration_test',
+      'if': "matrix.host.platform_name == 'windows_amd64'",
+    },
+  ]
 )


### PR DESCRIPTION
This change introduces a new WinFSP-based VFS implementation that goes alongside the existing FUSE and NFS VFS implementations. This enables bb_worker to succesfully execute bazel builds with virtualised file inputs with only a few drawbacks:

* Bazel really does require the Windows FS to be case insensitive, so I have had to add support for this within the VFS implementation.
* WinFSP does not support short file names and since bazel generates very long file paths, and many tools do not support long file paths (e.g. msvc), you can sometimes end up with file paths that exceed the maximum windows limit of 260. If this happens, you likely have to rename your bazel targets since WinFSP does not support short paths.

There are several forms of testing that have been done:

* There are unit tests for the WinFSP filesystem implementation that do not require WinFSP to be installed. These are quite exhaustive, with the exception of unit testing a couple of methods that are implemented by calling winfsp-provided methods.
* There are integration tests that use the winfsp-tests executable that check the filesystem behaves like a "proper windows filesystem". See https://winfsp.dev/doc/WinFsp-Tutorial/, for example. We exclude some tests from this for features we do not support, such as extended attributes.
* We have been running various versions of this in our build cluster for approximately 4 weeks with no problems.

This PR is just a draft but I'd like to get some feedback on a few specific points before I finish it, please:

1. I've vendored go-winfsp in the ffi package, as I found several issues with it and also needed to expose quite a few more functions. There are some options here:

   1. I could upstream the patches.
   2. We could use bazel to patch go-winfsp.
   3. We could stick with vendoring, in which case I will tidy up our vendored copy by, e.g., making it conform to the go style used in this repo.

   I'm happy to go with any of these.

4. I've added support for case insensitive folders for the static and in memory prepopulated directory implementations. This is a bit of an invasive change, but I cannot see another way around it.

5. I've not implemented support for removal notifications. WinFSP does have support for notifying it about file removals, but it's not clear to me that it's necessary: WinFSP itself handles removals that are initiated by it, so the only reason we would need this is if the VFS implementation (i.e. bb_worker) could delete files in parallel to an external process reading. Is that something that can happen?

6. This change introduces a new cmd, bb_virtual_dir, that just mounts a virtual file system at a particular path. This was quite helpful when developing this, particularly when debugging symlink handling. It's more of an internal testing tool though, so if you'd prefer me to remove it that's fine.