### PR TITLE
Update bb-storage and implement NewTicker

### DIFF
--- a/internal/mock/BUILD.bazel
+++ b/internal/mock/BUILD.bazel
@@ -111,6 +111,7 @@ gomock(
     interfaces = [
         "Clock",
         "Timer",
+        "Ticker",
     ],
     library = "@com_github_buildbarn_bb_storage//pkg/clock",
     mockgen_model_library = "@org_uber_go_mock//mockgen/model",

--- a/pkg/clock/BUILD.bazel
+++ b/pkg/clock/BUILD.bazel
@@ -14,6 +14,7 @@ go_test(
     deps = [
         ":clock",
         "//internal/mock",
+        "@com_github_buildbarn_bb_storage//pkg/clock",
         "@com_github_stretchr_testify//require",
         "@org_uber_go_mock//gomock",
     ],


### PR DESCRIPTION
This provides a simple implementation of NewTicker in terms of NewTimer. Testing this is a bit of a pain but these tests appear to pass robustly on my machine.