### PR TITLE
Let filepool files be owned by user

### DIFF
--- a/cmd/bb_worker/main.go
+++ b/cmd/bb_worker/main.go
@@ -226,7 +226,10 @@ func main() {
 					virtual.NewHandleAllocatingFileAllocator(
 						virtual.NewPoolBackedFileAllocator(
 							pool.EmptyFilePool,
-							util.DefaultErrorLogger),
+							util.DefaultErrorLogger,
+							/* ownerGroupID = */ 0,
+							/* ownerUserID = */ 0,
+						),
 						handleAllocator),
 					symlinkFactory,
 					util.DefaultErrorLogger,

--- a/pkg/builder/virtual_build_directory.go
+++ b/pkg/builder/virtual_build_directory.go
@@ -85,10 +85,10 @@ func (d *virtualBuildDirectory) EnterUploadableDirectory(name path.Component) (U
 func (d *virtualBuildDirectory) InstallHooks(filePool pool.FilePool, errorLogger util.ErrorLogger) {
 	d.PrepopulatedDirectory.InstallHooks(
 		virtual.NewHandleAllocatingFileAllocator(
-			virtual.NewPoolBackedFileAllocator(filePool, errorLogger),
+			virtual.NewPoolBackedFileAllocator(filePool, errorLogger, d.options.buildDirectoryOwnerGroupID, d.options.buildDirectoryOwnerUserID),
 			d.options.handleAllocator),
 		errorLogger,
-		/* defaultAttributesSetter = */ func(requested virtual.AttributesMask, attributes *virtual.Attributes) {
+		/* defaultAttributeSetter = */ func(requested virtual.AttributesMask, attributes *virtual.Attributes) {
 			attributes.SetOwnerUserID(d.options.buildDirectoryOwnerUserID)
 			attributes.SetOwnerGroupID(d.options.buildDirectoryOwnerGroupID)
 		},

--- a/pkg/filesystem/virtual/pool_backed_file_allocator_test.go
+++ b/pkg/filesystem/virtual/pool_backed_file_allocator_test.go
@@ -35,7 +35,7 @@ func TestPoolBackedFileAllocatorGetBazelOutputServiceStat(t *testing.T) {
 	pool.EXPECT().NewFile().Return(underlyingFile, nil)
 	errorLogger := mock.NewMockErrorLogger(ctrl)
 
-	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger).
+	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger, 0, 0).
 		NewFile(false, 0, virtual.ShareMaskRead|virtual.ShareMaskWrite)
 	require.Equal(t, virtual.StatusOK, s)
 
@@ -204,7 +204,7 @@ func TestPoolBackedFileAllocatorVirtualSeek(t *testing.T) {
 	pool.EXPECT().NewFile().Return(underlyingFile, nil)
 	errorLogger := mock.NewMockErrorLogger(ctrl)
 
-	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger).
+	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger, 0, 0).
 		NewFile(false, 0, virtual.ShareMaskRead|virtual.ShareMaskWrite)
 	require.Equal(t, virtual.StatusOK, s)
 
@@ -272,7 +272,7 @@ func TestPoolBackedFileAllocatorVirtualOpenSelfStaleAfterUnlink(t *testing.T) {
 	underlyingFile.EXPECT().Close()
 	errorLogger := mock.NewMockErrorLogger(ctrl)
 
-	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger).
+	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger, 0, 0).
 		NewFile(false, 0, virtual.ShareMaskWrite)
 	require.Equal(t, virtual.StatusOK, s)
 
@@ -297,7 +297,7 @@ func TestPoolBackedFileAllocatorVirtualOpenSelfStaleAfterClose(t *testing.T) {
 	underlyingFile.EXPECT().Close()
 	errorLogger := mock.NewMockErrorLogger(ctrl)
 
-	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger).
+	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger, 0, 0).
 		NewFile(false, 0, virtual.ShareMaskWrite)
 	require.Equal(t, virtual.StatusOK, s)
 
@@ -318,7 +318,7 @@ func TestPoolBackedFileAllocatorVirtualRead(t *testing.T) {
 	pool.EXPECT().NewFile().Return(underlyingFile, nil)
 	errorLogger := mock.NewMockErrorLogger(ctrl)
 
-	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger).
+	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger, 0, 0).
 		NewFile(false, 0, virtual.ShareMaskRead|virtual.ShareMaskWrite)
 	require.Equal(t, virtual.StatusOK, s)
 
@@ -397,7 +397,7 @@ func TestPoolBackedFileAllocatorFUSETruncateFailure(t *testing.T) {
 	errorLogger := mock.NewMockErrorLogger(ctrl)
 	errorLogger.EXPECT().Log(testutil.EqStatus(t, status.Error(codes.Unavailable, "Failed to truncate file to length 42: Storage backends offline")))
 
-	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger).
+	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger, 0, 0).
 		NewFile(false, 0, virtual.ShareMaskWrite)
 	require.Equal(t, virtual.StatusOK, s)
 
@@ -425,7 +425,7 @@ func TestPoolBackedFileAllocatorVirtualWriteFailure(t *testing.T) {
 	errorLogger := mock.NewMockErrorLogger(ctrl)
 	errorLogger.EXPECT().Log(testutil.EqStatus(t, status.Error(codes.Unavailable, "Failed to write to file at offset 42: Storage backends offline")))
 
-	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger).
+	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger, 0, 0).
 		NewFile(false, 0, virtual.ShareMaskWrite)
 	require.Equal(t, virtual.StatusOK, s)
 	_, s = f.VirtualWrite(p[:], 42)
@@ -443,7 +443,7 @@ func TestPoolBackedFileAllocatorUploadFile(t *testing.T) {
 	pool.EXPECT().NewFile().Return(underlyingFile, nil)
 	errorLogger := mock.NewMockErrorLogger(ctrl)
 
-	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger).
+	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger, 0, 0).
 		NewFile(false, 0, virtual.ShareMaskWrite)
 	require.Equal(t, virtual.StatusOK, s)
 
@@ -613,7 +613,7 @@ func TestPoolBackedFileAllocatorVirtualClose(t *testing.T) {
 	pool.EXPECT().NewFile().Return(underlyingFile, nil)
 	errorLogger := mock.NewMockErrorLogger(ctrl)
 
-	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger).
+	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger, 0, 0).
 		NewFile(false, 0, virtual.ShareMaskWrite)
 	require.Equal(t, virtual.StatusOK, s)
 


### PR DESCRIPTION
```
This commit extends the `buildDirectoryOwnerGroupId` and
`buildDirectoryOwnerUserId` fields to also apply to filepool backed
files. CAS-backed files remains owned by the root user.
```