### PR TITLE
Set ownership on files created by build actions during their execution

### DIFF
--- a/cmd/bb_worker/main.go
+++ b/cmd/bb_worker/main.go
@@ -222,12 +222,19 @@ func main() {
 				characterDeviceFactory = virtual.NewHandleAllocatingCharacterDeviceFactory(
 					virtual.BaseCharacterDeviceFactory,
 					handleAllocator.New())
+				defaultAttributesSetter := func(requested virtual.AttributesMask, attributes *virtual.Attributes) {
+					// No need to set ownership attributes
+					// on the top-level directory.
+				}
 				virtualBuildDirectory = virtual.NewInMemoryPrepopulatedDirectory(
 					virtual.NewHandleAllocatingFileAllocator(
 						virtual.NewPoolBackedFileAllocator(
 							pool.EmptyFilePool,
-							util.DefaultErrorLogger),
-						handleAllocator),
+							util.DefaultErrorLogger,
+							defaultAttributesSetter,
+						),
+						handleAllocator,
+					),
 					symlinkFactory,
 					util.DefaultErrorLogger,
 					handleAllocator,
@@ -235,11 +242,7 @@ func main() {
 					hiddenFilesPattern,
 					clock.SystemClock,
 					normalizer,
-					/* defaultAttributesSetter = */ func(requested virtual.AttributesMask, attributes *virtual.Attributes) {
-						// No need to set ownership
-						// attributes on the top-level
-						// directory.
-					},
+					defaultAttributesSetter,
 				)
 
 				if err := mount.Expose(dependenciesGroup, virtualBuildDirectory); err != nil {

--- a/pkg/builder/virtual_build_directory.go
+++ b/pkg/builder/virtual_build_directory.go
@@ -83,15 +83,18 @@ func (d *virtualBuildDirectory) EnterUploadableDirectory(name path.Component) (U
 }
 
 func (d *virtualBuildDirectory) InstallHooks(filePool pool.FilePool, errorLogger util.ErrorLogger) {
+	do := d.options
+	defaultAttributesSetter := func(requested virtual.AttributesMask, attributes *virtual.Attributes) {
+		attributes.SetOwnerUserID(do.buildDirectoryOwnerUserID)
+		attributes.SetOwnerGroupID(do.buildDirectoryOwnerGroupID)
+	}
 	d.PrepopulatedDirectory.InstallHooks(
 		virtual.NewHandleAllocatingFileAllocator(
-			virtual.NewPoolBackedFileAllocator(filePool, errorLogger),
-			d.options.handleAllocator),
+			virtual.NewPoolBackedFileAllocator(filePool, errorLogger, defaultAttributesSetter),
+			do.handleAllocator,
+		),
 		errorLogger,
-		/* defaultAttributesSetter = */ func(requested virtual.AttributesMask, attributes *virtual.Attributes) {
-			attributes.SetOwnerUserID(d.options.buildDirectoryOwnerUserID)
-			attributes.SetOwnerGroupID(d.options.buildDirectoryOwnerGroupID)
-		},
+		defaultAttributesSetter,
 	)
 }
 

--- a/pkg/filesystem/virtual/pool_backed_file_allocator_test.go
+++ b/pkg/filesystem/virtual/pool_backed_file_allocator_test.go
@@ -34,8 +34,10 @@ func TestPoolBackedFileAllocatorGetBazelOutputServiceStat(t *testing.T) {
 	underlyingFile := mock.NewMockFileReadWriter(ctrl)
 	pool.EXPECT().NewFile().Return(underlyingFile, nil)
 	errorLogger := mock.NewMockErrorLogger(ctrl)
+	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
+	defaultAttributesSetter.EXPECT().Call(gomock.Any(), gomock.Any()).AnyTimes()
 
-	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger).
+	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger, defaultAttributesSetter.Call).
 		NewFile(false, 0, virtual.ShareMaskRead|virtual.ShareMaskWrite)
 	require.Equal(t, virtual.StatusOK, s)
 
@@ -203,8 +205,10 @@ func TestPoolBackedFileAllocatorVirtualSeek(t *testing.T) {
 	underlyingFile := mock.NewMockFileReadWriter(ctrl)
 	pool.EXPECT().NewFile().Return(underlyingFile, nil)
 	errorLogger := mock.NewMockErrorLogger(ctrl)
+	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
+	defaultAttributesSetter.EXPECT().Call(gomock.Any(), gomock.Any()).AnyTimes()
 
-	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger).
+	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger, defaultAttributesSetter.Call).
 		NewFile(false, 0, virtual.ShareMaskRead|virtual.ShareMaskWrite)
 	require.Equal(t, virtual.StatusOK, s)
 
@@ -271,8 +275,9 @@ func TestPoolBackedFileAllocatorVirtualOpenSelfStaleAfterUnlink(t *testing.T) {
 	pool.EXPECT().NewFile().Return(underlyingFile, nil)
 	underlyingFile.EXPECT().Close()
 	errorLogger := mock.NewMockErrorLogger(ctrl)
+	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
 
-	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger).
+	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger, defaultAttributesSetter.Call).
 		NewFile(false, 0, virtual.ShareMaskWrite)
 	require.Equal(t, virtual.StatusOK, s)
 
@@ -296,8 +301,9 @@ func TestPoolBackedFileAllocatorVirtualOpenSelfStaleAfterClose(t *testing.T) {
 	pool.EXPECT().NewFile().Return(underlyingFile, nil)
 	underlyingFile.EXPECT().Close()
 	errorLogger := mock.NewMockErrorLogger(ctrl)
+	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
 
-	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger).
+	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger, defaultAttributesSetter.Call).
 		NewFile(false, 0, virtual.ShareMaskWrite)
 	require.Equal(t, virtual.StatusOK, s)
 
@@ -317,8 +323,9 @@ func TestPoolBackedFileAllocatorVirtualRead(t *testing.T) {
 	underlyingFile := mock.NewMockFileReadWriter(ctrl)
 	pool.EXPECT().NewFile().Return(underlyingFile, nil)
 	errorLogger := mock.NewMockErrorLogger(ctrl)
+	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
 
-	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger).
+	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger, defaultAttributesSetter.Call).
 		NewFile(false, 0, virtual.ShareMaskRead|virtual.ShareMaskWrite)
 	require.Equal(t, virtual.StatusOK, s)
 
@@ -397,7 +404,9 @@ func TestPoolBackedFileAllocatorFUSETruncateFailure(t *testing.T) {
 	errorLogger := mock.NewMockErrorLogger(ctrl)
 	errorLogger.EXPECT().Log(testutil.EqStatus(t, status.Error(codes.Unavailable, "Failed to truncate file to length 42: Storage backends offline")))
 
-	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger).
+	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
+
+	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger, defaultAttributesSetter.Call).
 		NewFile(false, 0, virtual.ShareMaskWrite)
 	require.Equal(t, virtual.StatusOK, s)
 
@@ -425,7 +434,9 @@ func TestPoolBackedFileAllocatorVirtualWriteFailure(t *testing.T) {
 	errorLogger := mock.NewMockErrorLogger(ctrl)
 	errorLogger.EXPECT().Log(testutil.EqStatus(t, status.Error(codes.Unavailable, "Failed to write to file at offset 42: Storage backends offline")))
 
-	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger).
+	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
+
+	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger, defaultAttributesSetter.Call).
 		NewFile(false, 0, virtual.ShareMaskWrite)
 	require.Equal(t, virtual.StatusOK, s)
 	_, s = f.VirtualWrite(p[:], 42)
@@ -442,8 +453,10 @@ func TestPoolBackedFileAllocatorUploadFile(t *testing.T) {
 	underlyingFile := mock.NewMockFileReadWriter(ctrl)
 	pool.EXPECT().NewFile().Return(underlyingFile, nil)
 	errorLogger := mock.NewMockErrorLogger(ctrl)
+	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
+	defaultAttributesSetter.EXPECT().Call(gomock.Any(), gomock.Any()).AnyTimes()
 
-	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger).
+	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger, defaultAttributesSetter.Call).
 		NewFile(false, 0, virtual.ShareMaskWrite)
 	require.Equal(t, virtual.StatusOK, s)
 
@@ -612,8 +625,10 @@ func TestPoolBackedFileAllocatorVirtualClose(t *testing.T) {
 	underlyingFile := mock.NewMockFileReadWriter(ctrl)
 	pool.EXPECT().NewFile().Return(underlyingFile, nil)
 	errorLogger := mock.NewMockErrorLogger(ctrl)
+	defaultAttributesSetter := mock.NewMockDefaultAttributesSetter(ctrl)
+	defaultAttributesSetter.EXPECT().Call(gomock.Any(), gomock.Any()).AnyTimes()
 
-	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger).
+	f, s := virtual.NewPoolBackedFileAllocator(pool, errorLogger, defaultAttributesSetter.Call).
 		NewFile(false, 0, virtual.ShareMaskWrite)
 	require.Equal(t, virtual.StatusOK, s)
 


### PR DESCRIPTION
Right now these files don't have ownership associated with them, meaning they will either be owned by root (FUSE) or by uid_t(-2) (NFSv4). This change extends PoolBackedFileAllocator to also accept a DefaultAttributesSetter, just like InMemoryPrepopulatedDirectory.

Fixes: #190