### PR TITLE
ci: use aspect-larger runners on Aspect Workflows CI

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -1,5 +1,6 @@
 # See https://docs.aspect.build/workflows/configuration
 tasks:
   - test:
+      queue: aspect-large
 notifications:
   github: {}


### PR DESCRIPTION
Larger runners are needed for this one