### PR TITLE
Move SectorAllocator into pkg/filesystem/pool

### DIFF
--- a/internal/mock/BUILD.bazel
+++ b/internal/mock/BUILD.bazel
@@ -171,10 +171,7 @@ gomock(
 gomock(
     name = "filesystem_re",
     out = "filesystem_re.go",
-    interfaces = [
-        "DirectoryOpener",
-        "SectorAllocator",
-    ],
+    interfaces = ["DirectoryOpener"],
     library = "//pkg/filesystem",
     mockgen_model_library = "@org_uber_go_mock//mockgen/model",
     mockgen_tool = "@org_uber_go_mock//mockgen",
@@ -186,6 +183,7 @@ gomock(
     out = "filesystem_filepool.go",
     interfaces = [
         "FilePool",
+        "SectorAllocator",
     ],
     library = "//pkg/filesystem/pool",
     mockgen_model_library = "@org_uber_go_mock//mockgen/model",

--- a/pkg/filesystem/BUILD.bazel
+++ b/pkg/filesystem/BUILD.bazel
@@ -2,11 +2,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "filesystem",
-    srcs = [
-        "bitmap_sector_allocator.go",
-        "lazy_directory.go",
-        "sector_allocator.go",
-    ],
+    srcs = ["lazy_directory.go"],
     importpath = "github.com/buildbarn/bb-remote-execution/pkg/filesystem",
     visibility = ["//visibility:public"],
     deps = [
@@ -14,16 +10,12 @@ go_library(
         "@com_github_buildbarn_bb_storage//pkg/filesystem/path",
         "@com_github_buildbarn_bb_storage//pkg/util",
         "@org_golang_google_grpc//codes",
-        "@org_golang_google_grpc//status",
     ],
 )
 
 go_test(
     name = "filesystem_test",
-    srcs = [
-        "bitmap_sector_allocator_test.go",
-        "lazy_directory_test.go",
-    ],
+    srcs = ["lazy_directory_test.go"],
     deps = [
         ":filesystem",
         "//internal/mock",

--- a/pkg/filesystem/pool/BUILD.bazel
+++ b/pkg/filesystem/pool/BUILD.bazel
@@ -3,17 +3,18 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "pool",
     srcs = [
+        "bitmap_sector_allocator.go",
         "block_device_backed_file_pool.go",
         "configuration.go",
         "empty_file_pool.go",
         "file_pool.go",
         "metrics_file_pool.go",
         "quota_enforcing_file_pool.go",
+        "sector_allocator.go",
     ],
     importpath = "github.com/buildbarn/bb-remote-execution/pkg/filesystem/pool",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/filesystem",
         "//pkg/proto/configuration/filesystem",
         "@com_github_buildbarn_bb_storage//pkg/blockdevice",
         "@com_github_buildbarn_bb_storage//pkg/filesystem",
@@ -27,6 +28,7 @@ go_library(
 go_test(
     name = "pool_test",
     srcs = [
+        "bitmap_sector_allocator_test.go",
         "block_device_backed_file_pool_test.go",
         "empty_file_pool_test.go",
         "quota_enforcing_file_pool_test.go",

--- a/pkg/filesystem/pool/bitmap_sector_allocator.go
+++ b/pkg/filesystem/pool/bitmap_sector_allocator.go
@@ -1,4 +1,4 @@
-package filesystem
+package pool
 
 import (
 	"fmt"

--- a/pkg/filesystem/pool/bitmap_sector_allocator_test.go
+++ b/pkg/filesystem/pool/bitmap_sector_allocator_test.go
@@ -1,9 +1,9 @@
-package filesystem_test
+package pool_test
 
 import (
 	"testing"
 
-	re_filesystem "github.com/buildbarn/bb-remote-execution/pkg/filesystem"
+	"github.com/buildbarn/bb-remote-execution/pkg/filesystem/pool"
 	"github.com/stretchr/testify/require"
 
 	"google.golang.org/grpc/codes"
@@ -11,7 +11,7 @@ import (
 )
 
 func TestBitmapSectorAllocatorExample(t *testing.T) {
-	sectorAllocator := re_filesystem.NewBitmapSectorAllocator(1000)
+	sectorAllocator := pool.NewBitmapSectorAllocator(1000)
 
 	// Allocate five regions of sectors that span all of storage.
 	for i := 0; i < 5; i++ {

--- a/pkg/filesystem/pool/block_device_backed_file_pool.go
+++ b/pkg/filesystem/pool/block_device_backed_file_pool.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 
-	re_filesystem "github.com/buildbarn/bb-remote-execution/pkg/filesystem"
 	"github.com/buildbarn/bb-storage/pkg/blockdevice"
 	"github.com/buildbarn/bb-storage/pkg/filesystem"
 
@@ -14,7 +13,7 @@ import (
 
 type blockDeviceBackedFilePool struct {
 	blockDevice     blockdevice.BlockDevice
-	sectorAllocator re_filesystem.SectorAllocator
+	sectorAllocator SectorAllocator
 	sectorSizeBytes int
 	zeroSector      []byte
 }
@@ -24,7 +23,7 @@ type blockDeviceBackedFilePool struct {
 // device tends to be faster than using a directory on a file system,
 // for the reason that no metadata (e.g., a directory hierarchy and
 // inode attributes) needs to be stored.
-func NewBlockDeviceBackedFilePool(blockDevice blockdevice.BlockDevice, sectorAllocator re_filesystem.SectorAllocator, sectorSizeBytes int) FilePool {
+func NewBlockDeviceBackedFilePool(blockDevice blockdevice.BlockDevice, sectorAllocator SectorAllocator, sectorSizeBytes int) FilePool {
 	return &blockDeviceBackedFilePool{
 		blockDevice:     blockDevice,
 		sectorAllocator: sectorAllocator,

--- a/pkg/filesystem/pool/configuration.go
+++ b/pkg/filesystem/pool/configuration.go
@@ -3,7 +3,6 @@ package pool
 import (
 	"math"
 
-	"github.com/buildbarn/bb-remote-execution/pkg/filesystem"
 	pb "github.com/buildbarn/bb-remote-execution/pkg/proto/configuration/filesystem"
 	"github.com/buildbarn/bb-storage/pkg/blockdevice"
 	"github.com/buildbarn/bb-storage/pkg/util"
@@ -34,7 +33,7 @@ func NewFilePoolFromConfiguration(configuration *pb.FilePoolConfiguration) (File
 		}
 		filePool = NewBlockDeviceBackedFilePool(
 			blockDevice,
-			filesystem.NewBitmapSectorAllocator(uint32(sectorCount)),
+			NewBitmapSectorAllocator(uint32(sectorCount)),
 			sectorSizeBytes)
 	default:
 		return nil, status.Error(codes.InvalidArgument, "Configuration did not contain a supported file pool backend")

--- a/pkg/filesystem/pool/sector_allocator.go
+++ b/pkg/filesystem/pool/sector_allocator.go
@@ -1,4 +1,4 @@
-package filesystem
+package pool
 
 // SectorAllocator is used by BlockDeviceBackedFilePool to allocate
 // space on the block device that is needed to store files.

--- a/pkg/filesystem/virtual/winfsp/BUILD.bazel
+++ b/pkg/filesystem/virtual/winfsp/BUILD.bazel
@@ -68,7 +68,6 @@ go_test(
     tags = ["manual"],
     deps = select({
         "@rules_go//go/platform:windows": [
-            "//pkg/filesystem",
             "//pkg/filesystem/pool",
             "//pkg/filesystem/virtual",
             "//pkg/filesystem/virtual/configuration",

--- a/pkg/filesystem/virtual/winfsp/file_system_integration_test.go
+++ b/pkg/filesystem/virtual/winfsp/file_system_integration_test.go
@@ -16,7 +16,6 @@ import (
 
 	ffi "github.com/aegistudio/go-winfsp"
 	"github.com/bazelbuild/rules_go/go/runfiles"
-	"github.com/buildbarn/bb-remote-execution/pkg/filesystem"
 	"github.com/buildbarn/bb-remote-execution/pkg/filesystem/pool"
 	"github.com/buildbarn/bb-remote-execution/pkg/filesystem/virtual"
 	virtual_configuration "github.com/buildbarn/bb-remote-execution/pkg/filesystem/virtual/configuration"
@@ -83,7 +82,7 @@ func createWinFSPMountForTest(t *testing.T, terminationGroup program.Group, case
 				virtual.NewPoolBackedFileAllocator(
 					pool.NewBlockDeviceBackedFilePool(
 						bd,
-						filesystem.NewBitmapSectorAllocator(uint32(sectorCount)),
+						pool.NewBitmapSectorAllocator(uint32(sectorCount)),
 						sectorSizeBytes,
 					),
 					util.DefaultErrorLogger,


### PR DESCRIPTION
SectorAllocator is only used by the FilePool code, so there's no point in keeping it in pkg/filesystem.