### PR TITLE
chore(golang): update to 1.26.2 / CVE-2026-27143

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -3678,162 +3678,162 @@
           "8f2d8e6dd0849a2ec0ade1683bcfb7809e64d264a4273d8437841000a28ffb60"
         ]
       },
-      "1.26.1": {
+      "1.26.2": {
         "aix_ppc64": [
-          "go1.26.1.aix-ppc64.tar.gz",
-          "75441456c5fb8338b2691d22d7e91cc756f79defaa4268d6e04ab85ca1a1f4a3"
+          "go1.26.2.aix-ppc64.tar.gz",
+          "e6f759fbdd5b1e3ecce3161d8bd9b9aeaf15c4112b7c101097e9d329b310d858"
         ],
         "darwin_amd64": [
-          "go1.26.1.darwin-amd64.tar.gz",
-          "65773dab2f8cc4cd23d93ba6d0a805de150ca0b78378879292be0b903b8cdd08"
+          "go1.26.2.darwin-amd64.tar.gz",
+          "bc3f1500d9968c36d705442d90ba91addf9271665033748b82532682e90a7966"
         ],
         "darwin_arm64": [
-          "go1.26.1.darwin-arm64.tar.gz",
-          "353df43a7811ce284c8938b5f3c7df40b7bfb6f56cb165b150bc40b5e2dd541f"
+          "go1.26.2.darwin-arm64.tar.gz",
+          "32af1522bf3e3ff3975864780a429cc0b41d190ec7bf90faa661d6d64566e7af"
         ],
         "dragonfly_amd64": [
-          "go1.26.1.dragonfly-amd64.tar.gz",
-          "f415e65bfcb03989a4b6eddedcd582cd509ea619af588b1341416216642c78fb"
+          "go1.26.2.dragonfly-amd64.tar.gz",
+          "b4f3f74412914e54140cbf8b5c76d2f8eeff3a5003310c9244c61ba8a0ecd94b"
         ],
         "freebsd_386": [
-          "go1.26.1.freebsd-386.tar.gz",
-          "afb86dcd5240cf93627171a169973c75d9d139a69ed8e0be120d49b24943c13f"
+          "go1.26.2.freebsd-386.tar.gz",
+          "fab09ea1988aae3ae2c8186455e8956d539d04e2ee4973e8887853432d0e8039"
         ],
         "freebsd_amd64": [
-          "go1.26.1.freebsd-amd64.tar.gz",
-          "d89034a0b54fdc234815fecfb76d7d06a7d180d7a6124aa47715a4cacc9fe999"
+          "go1.26.2.freebsd-amd64.tar.gz",
+          "f271fd829a2a6b36fa1c72cdaafb18410a106da982c93a626d4e8b0fa0f0fa21"
         ],
         "freebsd_arm": [
-          "go1.26.1.freebsd-arm.tar.gz",
-          "c60b5b09a24680e40a906df62af71563af4cca0106f01390f2a2346bbfbc4aaa"
+          "go1.26.2.freebsd-arm.tar.gz",
+          "38713f1516cd2b0097ea05594ec1c842fe690dace8301c7d34d91b92250b4424"
         ],
         "freebsd_arm64": [
-          "go1.26.1.freebsd-arm64.tar.gz",
-          "d62b358dbf7bcfc33402e7e221d848e7fd8d7ac902b33920f2c23c8a32ba76db"
+          "go1.26.2.freebsd-arm64.tar.gz",
+          "d78bb171900134efdd1d0d49e5e80cd8c8b614f0e46c508d0b6bac30fb996fdf"
         ],
         "illumos_amd64": [
-          "go1.26.1.illumos-amd64.tar.gz",
-          "78e9a3d99fab9626b773a859f28f69ca5240846487f51b92b51251ef04f210bc"
+          "go1.26.2.illumos-amd64.tar.gz",
+          "e88cd85e9e253ceda4077367072aa10d2f92bc2fa6e59a811c00bbe95dc9b02d"
         ],
         "linux_386": [
-          "go1.26.1.linux-386.tar.gz",
-          "da75d696c6b9440fe9fb6418429f29eaeee947707ee8c6ddb567c558051a1cc2"
+          "go1.26.2.linux-386.tar.gz",
+          "89835cdc4dfebde7fe28c9c6dc080bb3753f6b0354301966ff9f62d14991bd7d"
         ],
         "linux_amd64": [
-          "go1.26.1.linux-amd64.tar.gz",
-          "031f088e5d955bab8657ede27ad4e3bc5b7c1ba281f05f245bcc304f327c987a"
+          "go1.26.2.linux-amd64.tar.gz",
+          "990e6b4bbba816dc3ee129eaeaf4b42f17c2800b88a2166c265ac1a200262282"
         ],
         "linux_arm64": [
-          "go1.26.1.linux-arm64.tar.gz",
-          "a290581cfe4fe28ddd737dde3095f3dbeb7f2e4065cab4eae44dfc53b760c2f7"
+          "go1.26.2.linux-arm64.tar.gz",
+          "c958a1fe1b361391db163a485e21f5f228142d6f8b584f6bef89b26f66dc5b23"
         ],
         "linux_armv6l": [
-          "go1.26.1.linux-armv6l.tar.gz",
-          "c9937198994dc173b87630a94a0d323442bef81bf7589b1170d55a8ebf759bda"
+          "go1.26.2.linux-armv6l.tar.gz",
+          "0000e45577827b0a8868588c543cbe4232853def1d3d7a344ad6e60ce2b015c8"
         ],
         "linux_loong64": [
-          "go1.26.1.linux-loong64.tar.gz",
-          "922b0f308771ce7e162f6c14a9d4bc86db329eaacf6db875e967ad7e5a6b065c"
+          "go1.26.2.linux-loong64.tar.gz",
+          "4dcb87e845fe5c015c8cf6affb4636fcf1699182b70454783caed85c5dfa3267"
         ],
         "linux_mips": [
-          "go1.26.1.linux-mips.tar.gz",
-          "8711f0396539d9051f27b7743c69ab48359dea75cfaa37b8c70b6ddf6b5d8259"
+          "go1.26.2.linux-mips.tar.gz",
+          "2d57e4167932a4872e31570465f48d8b6818002c77275bae969bdbb6d7238b5e"
         ],
         "linux_mips64": [
-          "go1.26.1.linux-mips64.tar.gz",
-          "bbe2604bdf51e08d6386da7632f07379f88f31b2431ae71839a7064201a8ffd3"
+          "go1.26.2.linux-mips64.tar.gz",
+          "b0b49bb5c528e623a926b8242f03cfd612971150e18eeb3f638d751218c09cdf"
         ],
         "linux_mips64le": [
-          "go1.26.1.linux-mips64le.tar.gz",
-          "1d97c7293a9760afb4a6e02d19e627d7eecea75b4f06096fd39b7977e4830b96"
+          "go1.26.2.linux-mips64le.tar.gz",
+          "5ffc9da2b0ee939c8503c9d9278d6857909ca8577dae3b71221ab2821dc7826a"
         ],
         "linux_mipsle": [
-          "go1.26.1.linux-mipsle.tar.gz",
-          "2051d0dc77d8e35aaab39236ae1f913098bbee493c7ed6a6281a8dd5dc1e5db7"
+          "go1.26.2.linux-mipsle.tar.gz",
+          "ab1fe1c38ffa6bbda029dea33bf36167aca4ff3a25c9d6ed0af38da120678ddc"
         ],
         "linux_ppc64": [
-          "go1.26.1.linux-ppc64.tar.gz",
-          "a14f56b7483c3829e7eb92766956b0b7c3cbb21d055d31c3d327a15baf5535c6"
+          "go1.26.2.linux-ppc64.tar.gz",
+          "589f7ef241104f153e910244b71d70f4aad0d4584651ca80a5188186dda63a2e"
         ],
         "linux_ppc64le": [
-          "go1.26.1.linux-ppc64le.tar.gz",
-          "f56eed002998f5f51fa07fd4ed0c5de5e02d51cec7a4007f771c7576620d9d45"
+          "go1.26.2.linux-ppc64le.tar.gz",
+          "62b7645dd2404052535617c59e91cf03c7aa28e332dbaddbe4c0d7de7bcc6736"
         ],
         "linux_riscv64": [
-          "go1.26.1.linux-riscv64.tar.gz",
-          "56f8a63ae986c75e91001d65e17648564a10f0d2b18d696d13c91e459da1abd4"
+          "go1.26.2.linux-riscv64.tar.gz",
+          "c5c697faa4dc05364b6e163d2ab8161b32a120eeed54192457d57d7ef7c2091a"
         ],
         "linux_s390x": [
-          "go1.26.1.linux-s390x.tar.gz",
-          "60fe623ef63e6338c055ec0e0e3f4fa85c97a056de2d2f6ee38591e2bfa9cdde"
+          "go1.26.2.linux-s390x.tar.gz",
+          "410726ed10a0ea6745c2ea8da4f0e769fd3ce819cd4a41a67ad08b094d5dfc31"
         ],
         "netbsd_386": [
-          "go1.26.1.netbsd-386.tar.gz",
-          "158b816ce02a2a8cb07aca558bd332ba3b6f56d3b873f48979231f8beaa458a1"
+          "go1.26.2.netbsd-386.tar.gz",
+          "e8ffab99dd65fef14097d6af48ea6302793f2298a7b2e5f00a284bd933feba4c"
         ],
         "netbsd_amd64": [
-          "go1.26.1.netbsd-amd64.tar.gz",
-          "42bf3dba3d2c023fb7cce66806e300d389951b2ba50484eb6a2d8cdb8baa8b50"
+          "go1.26.2.netbsd-amd64.tar.gz",
+          "1f5c33c923983ee8433ad8098dcd87a0e1fdccd18d05a91844c2be60507a61fe"
         ],
         "netbsd_arm": [
-          "go1.26.1.netbsd-arm.tar.gz",
-          "7107542cc768b1bdf713e33e7034dd2a5ca98e7357643c2c9695c6be5176a590"
+          "go1.26.2.netbsd-arm.tar.gz",
+          "85761320e364b65424d2952a3388970d86e072c8dce8dcad2a1dca41555c2b96"
         ],
         "netbsd_arm64": [
-          "go1.26.1.netbsd-arm64.tar.gz",
-          "498845f0c6b5eb3136c1a21b87940e55a039639f0757b91016172e67ce899032"
+          "go1.26.2.netbsd-arm64.tar.gz",
+          "3ca3561bf4452e799d11e5312182f79cd342d506136cd44c2b47991206ec23f5"
         ],
         "openbsd_386": [
-          "go1.26.1.openbsd-386.tar.gz",
-          "aba9d96b620eac5a3b47c0e58dc2a2d773c365991a6e1a9b681b8c77542adbed"
+          "go1.26.2.openbsd-386.tar.gz",
+          "0644073c0ae1ade26d26953ef882d7d419855dca25b0e992ae416a47967d37b3"
         ],
         "openbsd_amd64": [
-          "go1.26.1.openbsd-amd64.tar.gz",
-          "8801baa1cc9d221b863b005555ba3c6cbd27fb50b651f7e31ea129d0ada27577"
+          "go1.26.2.openbsd-amd64.tar.gz",
+          "72f69217a88e3d0975a75adf9fc92ff10ea65def56e6c34d8612428bf769581e"
         ],
         "openbsd_arm": [
-          "go1.26.1.openbsd-arm.tar.gz",
-          "cdeb25b4d496c3e6610d86292af8c2699bca40cfdad27dd6366ea032e29f233b"
+          "go1.26.2.openbsd-arm.tar.gz",
+          "3aafe792df65abf1777b5cc678075ebba1bd8063e6450e81e742fef696e0bcbd"
         ],
         "openbsd_arm64": [
-          "go1.26.1.openbsd-arm64.tar.gz",
-          "398f0074552368b0f8d874712a69bb4c999d16edaceaa31ff7dde735f524e815"
+          "go1.26.2.openbsd-arm64.tar.gz",
+          "efd410fc60a17690ad43fe8dd00bf1fd4c1dc920d81970b9f422f313b0930b92"
         ],
         "openbsd_ppc64": [
-          "go1.26.1.openbsd-ppc64.tar.gz",
-          "74e95fa65c22cd2ab09a69532517bac51da5a66827766abd721f20a4fd9120dc"
+          "go1.26.2.openbsd-ppc64.tar.gz",
+          "98a2cadd416066739e00b1bc297727c3108dba9001811b177ce57afef518f8bd"
         ],
         "openbsd_riscv64": [
-          "go1.26.1.openbsd-riscv64.tar.gz",
-          "1a78ed5f05959bda1a7feee108bb96fd46ca50f8f8ff60484fef0b6436bf36c0"
+          "go1.26.2.openbsd-riscv64.tar.gz",
+          "adf39a1a7e56d5c1a2cb69ad06752c5da6b808d2a029b7b6d6d5bb6e11a2168e"
         ],
         "plan9_386": [
-          "go1.26.1.plan9-386.tar.gz",
-          "214a665bbf5204caa1111a15a9607b3f0057ea9721e0dafbd5a71303de0708c4"
+          "go1.26.2.plan9-386.tar.gz",
+          "eb2f95f6f43701eb98a31f5efdd9b5f14ff6e0afd289e1f94559462f83e73cfd"
         ],
         "plan9_amd64": [
-          "go1.26.1.plan9-amd64.tar.gz",
-          "c6b0bd3c0f0f4c62191c665a27df9f79470572ad29ecf6064368f3bde43c14bc"
+          "go1.26.2.plan9-amd64.tar.gz",
+          "d347fecec7532309fccf3570021ba8a00a0acce120fea02a46cc295936588b0f"
         ],
         "plan9_arm": [
-          "go1.26.1.plan9-arm.tar.gz",
-          "9caf03c5455fe14dd622cba54edc4655a895e302f09e34a6dd19c4ebc7c53786"
+          "go1.26.2.plan9-arm.tar.gz",
+          "70700c5af45201a8e82436fb824f3551e357e3002094c8416e78e1aa51d4a0ab"
         ],
         "solaris_amd64": [
-          "go1.26.1.solaris-amd64.tar.gz",
-          "e9d67570e05e43120692be78bf7497a22ff413526f8d6b7378bba9607a151b5b"
+          "go1.26.2.solaris-amd64.tar.gz",
+          "cd45d13200697b3263e39cdf364f0cb9d9adc39d9574ab575e481b64cb7fb8b1"
         ],
         "windows_386": [
-          "go1.26.1.windows-386.zip",
-          "6a26b7ce038d96d2b3457ea4933667fb85c896411860216daf6ea17ecd4b25c5"
+          "go1.26.2.windows-386.zip",
+          "4a8b02c34625fecd9c6583442101c9796fc265a5fc1edb9340d71bed0300f94c"
         ],
         "windows_amd64": [
-          "go1.26.1.windows-amd64.zip",
-          "9b68112c913f45b7aebbf13c036721264bbba7e03a642f8f7490c561eebd1ecc"
+          "go1.26.2.windows-amd64.zip",
+          "98eb3570bade15cb826b0909338df6cc6d2cf590bc39c471142002db3832b708"
         ],
         "windows_arm64": [
-          "go1.26.1.windows-arm64.zip",
-          "c17e09676be0faad3cbed1c81bb02f38fb73e2f93d048571cc13730fe23f2d5b"
+          "go1.26.2.windows-arm64.zip",
+          "094d05caaf6ba235e2bd570b625d064ceb65943866252722a8f3fdba232139c6"
         ]
       }
     }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildbarn/bb-remote-execution
 
-go 1.26.1
+go 1.26.2
 
 // rules_go doesn't support gomock's package mode.
 replace go.uber.org/mock => go.uber.org/mock v0.4.0


### PR DESCRIPTION
This fixes multiple security problems inside golang including CVE-2026-27143 

more details here:
https://groups.google.com/g/golang-announce/c/0uYbvbPZRWU

https://pkg.go.dev/vuln/GO-2026-4868
https://www.cve.org/CVERecord?id=CVE-2026-27143


[Markus Sattler](mailto:markus.satter@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH

[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)