### PR TITLE
chore(golang): update golang version to 1.26.4

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -5127,6 +5127,164 @@
           "go1.26.3.windows-arm64.zip",
           "95cd63bc6b0da77409ba819215afea9ddf5702c55a3b20af3dd90ea95c7b130c"
         ]
+      },
+      "1.26.4": {
+        "aix_ppc64": [
+          "go1.26.4.aix-ppc64.tar.gz",
+          "881bf44c07203fc1759d477412c2dfae425e5d2023acdd79299d5de5b4de8e77"
+        ],
+        "darwin_amd64": [
+          "go1.26.4.darwin-amd64.tar.gz",
+          "05dc9b5f9997744520aaebb3d5deaa7c755371aebbfb7f97c2511a9f3367538d"
+        ],
+        "darwin_arm64": [
+          "go1.26.4.darwin-arm64.tar.gz",
+          "b62ad2b6d7d2464f12a5bcad7ff47f19d08325773b5efd21610e445a05a9bf53"
+        ],
+        "dragonfly_amd64": [
+          "go1.26.4.dragonfly-amd64.tar.gz",
+          "bcc3ee1cfb6dd03a2d5abf07174212df1764ae54406c389b71a7fd2d05a8f0c8"
+        ],
+        "freebsd_386": [
+          "go1.26.4.freebsd-386.tar.gz",
+          "f4325e0f9a5894e79c60b5e692af55a1e6f261b8ea73dcd20eced8372ad08233"
+        ],
+        "freebsd_amd64": [
+          "go1.26.4.freebsd-amd64.tar.gz",
+          "e91e96c0d3bd8f770e5a0facaf21d010a84e1c9440d830210cb3c223f0b7fb50"
+        ],
+        "freebsd_arm": [
+          "go1.26.4.freebsd-arm.tar.gz",
+          "36e45b3a843087f0f95a71f2ed453ea7e1727e684644d13f8b4c6c93fd977d41"
+        ],
+        "freebsd_arm64": [
+          "go1.26.4.freebsd-arm64.tar.gz",
+          "34aee1071d74cc23703d1b415c5fa44f840d29fd3733dac34944d83cfada3ff3"
+        ],
+        "illumos_amd64": [
+          "go1.26.4.illumos-amd64.tar.gz",
+          "27603bcd431afab272a5ed81cc951146181e8139640c46ed2ea5b560e1097038"
+        ],
+        "linux_386": [
+          "go1.26.4.linux-386.tar.gz",
+          "5ca0982791791559d11a0eba939617a94c3f37c21aa514a55c415b9167efc658"
+        ],
+        "linux_amd64": [
+          "go1.26.4.linux-amd64.tar.gz",
+          "1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f"
+        ],
+        "linux_arm64": [
+          "go1.26.4.linux-arm64.tar.gz",
+          "ef758ae7c6cf9267c9c0ef080b8965f453d89ab2d25d9eb22de4405925238768"
+        ],
+        "linux_armv6l": [
+          "go1.26.4.linux-armv6l.tar.gz",
+          "8db458e995f18a9427a745cefe7a3323962fa2548c4715148963311f300d3b1a"
+        ],
+        "linux_loong64": [
+          "go1.26.4.linux-loong64.tar.gz",
+          "9f6d288d8972dd649ff3ecfdd3ed98e0664b5efb432e841408c054c25af26ed3"
+        ],
+        "linux_mips": [
+          "go1.26.4.linux-mips.tar.gz",
+          "3435d0d8424562dfcf12517040b6a2388ee0f6f20b9d66b2349a6c5034d57997"
+        ],
+        "linux_mips64": [
+          "go1.26.4.linux-mips64.tar.gz",
+          "691263ab84943aff78d1422dfae66f352d907fc67560e66e7ceec3898fb7d5e6"
+        ],
+        "linux_mips64le": [
+          "go1.26.4.linux-mips64le.tar.gz",
+          "23946b019b118ed85676090fd9110cfa091667c8c52d3d5276b73f3dd46d31f4"
+        ],
+        "linux_mipsle": [
+          "go1.26.4.linux-mipsle.tar.gz",
+          "4436df043e2a448f8937d1f944a3cd786d815c872fdce38dd892269845c1c54f"
+        ],
+        "linux_ppc64": [
+          "go1.26.4.linux-ppc64.tar.gz",
+          "d7c3970c1818d63b7b3473a01b9f5f208da1e793a902d3b2e26d5e5174eb6026"
+        ],
+        "linux_ppc64le": [
+          "go1.26.4.linux-ppc64le.tar.gz",
+          "53f49b8c7eace2d30389327b4a516b13321f90377fdf5929a6b63174609bc22e"
+        ],
+        "linux_riscv64": [
+          "go1.26.4.linux-riscv64.tar.gz",
+          "2b9ba137baaa3031fd74330cb36ab54c5abe380867ca9fbab7c552f3db740555"
+        ],
+        "linux_s390x": [
+          "go1.26.4.linux-s390x.tar.gz",
+          "1e12a2318f3dd4c57027c865f6cb51f5d1e36b02d10f3e6316ce7b61a27b3ca1"
+        ],
+        "netbsd_386": [
+          "go1.26.4.netbsd-386.tar.gz",
+          "67a172e4780d1b2a5412b73e86798937f2eb2f85aba6d740df4fbe6d6b555fa2"
+        ],
+        "netbsd_amd64": [
+          "go1.26.4.netbsd-amd64.tar.gz",
+          "3321f16e91c7d6d9c8df556690fbe8aef028aac9a0d6d466af9d3c20bd599503"
+        ],
+        "netbsd_arm": [
+          "go1.26.4.netbsd-arm.tar.gz",
+          "a3830f9f0f9fb00648346508d4d2c6fa2d7c1cd4c478fb88051ff6f1b49f0610"
+        ],
+        "netbsd_arm64": [
+          "go1.26.4.netbsd-arm64.tar.gz",
+          "f240a98583a12f16cd6ea4799d29e5ccdc96892314263c0065e6511c783e26ab"
+        ],
+        "openbsd_386": [
+          "go1.26.4.openbsd-386.tar.gz",
+          "c0c892180ebc9038637f158a010bdc2d962d303d9c0346ae5856fcd2088b16c7"
+        ],
+        "openbsd_amd64": [
+          "go1.26.4.openbsd-amd64.tar.gz",
+          "cd33f8f7f103cc9151d69795a7f20482335a88cf4eb76a3c56c12afbb5b1b2f0"
+        ],
+        "openbsd_arm": [
+          "go1.26.4.openbsd-arm.tar.gz",
+          "5ab1a54a1dc4f425006101b81c12cd88a457b22496add2bb8b6f6e73b58cf1f1"
+        ],
+        "openbsd_arm64": [
+          "go1.26.4.openbsd-arm64.tar.gz",
+          "cf8b0f5d6a043771df53fe70054d2b2b792f4c7693ad6cd5a891c252d813bc33"
+        ],
+        "openbsd_ppc64": [
+          "go1.26.4.openbsd-ppc64.tar.gz",
+          "dcf7c6962c43ff67a0d804b989589fe4f3fd574c92b932659c95b1bb32c66f82"
+        ],
+        "openbsd_riscv64": [
+          "go1.26.4.openbsd-riscv64.tar.gz",
+          "e6ba2daf626770f7d453e7974058dee4b85cb198613ecbb97048a730dc1d5497"
+        ],
+        "plan9_386": [
+          "go1.26.4.plan9-386.tar.gz",
+          "003b912f269786612ad01088178ffcb6f03421fdd61cc4d8b71922571aabd09a"
+        ],
+        "plan9_amd64": [
+          "go1.26.4.plan9-amd64.tar.gz",
+          "663871da0f2263d6553828e695be5346f816015f1a6fe7ead22db538ebb6b293"
+        ],
+        "plan9_arm": [
+          "go1.26.4.plan9-arm.tar.gz",
+          "9b350fc94bb0c17fe30604e41c7573a9a70bbab258646f0e262a4c6851e4d2b8"
+        ],
+        "solaris_amd64": [
+          "go1.26.4.solaris-amd64.tar.gz",
+          "92eb3f7e224e5dd7ac9e0fb9455f8619c3999faf1e350a9505bb2ed5f7e41b7e"
+        ],
+        "windows_386": [
+          "go1.26.4.windows-386.zip",
+          "2064a4a249fd2ee2db23e7080dc19b42768969f2830541841d0f7a9c80996946"
+        ],
+        "windows_amd64": [
+          "go1.26.4.windows-amd64.zip",
+          "3ca8fb4630b07c419cbdd51f754e31363cfcfb83b3a5354d9e895c90be2cc345"
+        ],
+        "windows_arm64": [
+          "go1.26.4.windows-arm64.zip",
+          "62247f56fb7d7b827d237152c4e3fcd69a24d0fa9430dc73dbda7593ae82bc8d"
+        ]
       }
     }
   }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildbarn/bb-remote-execution
 
-go 1.26.3
+go 1.26.4
 
 // rules_go doesn't support gomock's package mode.
 replace go.uber.org/mock => go.uber.org/mock v0.4.0


### PR DESCRIPTION
This PR updates the golang version to 1.26.4

[release notes](https://go.dev/doc/devel/release#go1.26.minor)
[issues](https://github.com/golang/go/issues?q=label%3ACherryPickApproved%20milestone%3AGo1.26.4)

[Markus Sattler](mailto:markus.satter@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH

[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)