### PR TITLE
Upgrade go-winfsp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
-	github.com/winfsp/go-winfsp v1.0.3
+	github.com/winfsp/go-winfsp v1.0.4-0.20260614140859-496ed3bd9019
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.uber.org/mock v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/winfsp/go-winfsp v1.0.3 h1:t6PIbKBCHfeij5PzWlox9uByS2hsgzyUwr4cM2zVhIc=
-github.com/winfsp/go-winfsp v1.0.3/go.mod h1:aE+JiVxKhiHzrCTmmk1aB83aZv68JAQqUO+jni6q1Cg=
+github.com/winfsp/go-winfsp v1.0.4-0.20260614140859-496ed3bd9019 h1:Jy4qRRfDYKyE807UQ4b+UhA/qRkEDKUWsCXbaEf+6g8=
+github.com/winfsp/go-winfsp v1.0.4-0.20260614140859-496ed3bd9019/go.mod h1:aE+JiVxKhiHzrCTmmk1aB83aZv68JAQqUO+jni6q1Cg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=


### PR DESCRIPTION
The main advantage is that it fixes two bugs that affect bb_worker:

- PosixMapUidToSid would leak a SID on every call.
- Mounting could crash if a parallel Go GC occurred.